### PR TITLE
Story/959/5023 - Data tabulator via configuration

### DIFF
--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/config/RosettaGeneratorsConfiguration.java
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/config/RosettaGeneratorsConfiguration.java
@@ -14,7 +14,7 @@ public class RosettaGeneratorsConfiguration {
 	private final RosettaTabulatorConfiguration rosettaTabulatorConfiguration;
 
 	public RosettaGeneratorsConfiguration() {
-		this(n -> true, new RosettaTabulatorConfiguration(List.of()));
+		this(n -> true, new RosettaTabulatorConfiguration(List.of(), List.of()));
 	}
 	public RosettaGeneratorsConfiguration(Predicate<String> namespaceFilter, RosettaTabulatorConfiguration tabulators) {
 		Objects.requireNonNull(namespaceFilter);

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/config/RosettaTabulatorConfiguration.java
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/config/RosettaTabulatorConfiguration.java
@@ -9,20 +9,27 @@ import org.apache.commons.lang3.Validate;
 
 public class RosettaTabulatorConfiguration {
 	private final List<String> annotations;
+	private final List<String> types;
 
 	public RosettaTabulatorConfiguration() {
-		this(Collections.emptyList());
+		this(Collections.emptyList(), Collections.emptyList());
 	}
-	public RosettaTabulatorConfiguration(List<String> annotations) {
+	public RosettaTabulatorConfiguration(List<String> annotations, List<String> types) {
 		Validate.noNullElements(annotations);
+		Validate.noNullElements(types);
 		
 		this.annotations = annotations;
+		this.types = types;
 	}
 
 	public List<String> getAnnotations() {
 		return annotations;
 	}
 	
+	public List<String> getTypes() {
+		return types;
+	}
+
 	public static class Provider  implements javax.inject.Provider<RosettaTabulatorConfiguration> {
 		private final RosettaConfiguration config;
 		@Inject

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/config/file/RosettaTabulatorConfigurationMixin.java
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/config/file/RosettaTabulatorConfigurationMixin.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public abstract class RosettaTabulatorConfigurationMixin {
 	@JsonCreator
-	public RosettaTabulatorConfigurationMixin(@JsonProperty("annotations") List<String> annotations ) {}
+	public RosettaTabulatorConfigurationMixin(@JsonProperty("annotations") List<String> annotations,
+			@JsonProperty("types") List<String> types) {}
 
 }

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/RosettaGenerator.xtend
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/RosettaGenerator.xtend
@@ -175,6 +175,7 @@ class RosettaGenerator implements IGenerator2 {
 							if (deepFeatureCallUtil.isEligibleForDeepFeatureCall(new RDataType(it))) {
 								deepPathUtilGenerator.generate(fsa, it, version)
 							}
+							tabulatorGenerator.generate(fsa, it)
 						}
 						Function: {
 							if (!isDispatchingFunction) {

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/reports/TabulatorGenerator.xtend
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/reports/TabulatorGenerator.xtend
@@ -191,7 +191,7 @@ class TabulatorGenerator {
 	}
 	
 	def generate(IFileSystemAccess2 fsa, Data data) {
-		if (data.isTypeTabulatable) {
+		if (data.isDataTabulatable) {
 			val context = createDataTabulatorContext(typeTranslator, data)
 
 			val tabulatorClass = data.toTabulatorJavaClass
@@ -255,7 +255,7 @@ class TabulatorGenerator {
 		}
 	}
 	
-	private def boolean isTypeTabulatable(Data type) {
+	private def boolean isDataTabulatable(Data type) {
 		val types = rosettaConfiguration.generators.tabulators.types
 		val fqn = String.format("%s.%s", type.model.name, type.name)
 		types.contains(fqn)

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/reports/TabulatorGenerator.xtend
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/reports/TabulatorGenerator.xtend
@@ -137,7 +137,6 @@ class TabulatorGenerator {
 	@org.eclipse.xtend.lib.annotations.Data
 	private static class DataTabulatorContext implements TabulatorContext {
 		extension JavaTypeTranslator typeTranslator
-		Data data
 
 		override needsTabulator(Data type) {
 			true
@@ -190,14 +189,14 @@ class TabulatorGenerator {
 		}
 	}
 	
-	def generate(IFileSystemAccess2 fsa, Data data) {
-		if (data.isDataTabulatable) {
-			val context = createDataTabulatorContext(typeTranslator, data)
+	def generate(IFileSystemAccess2 fsa, Data type) {
+		if (type.isDataTabulatable) {
+			val context = createDataTabulatorContext(typeTranslator)
 
-			val tabulatorClass = data.toTabulatorJavaClass
+			val tabulatorClass = type.toTabulatorJavaClass
 			val topScope = new JavaScope(tabulatorClass.packageName)
 
-			generateTabulator(data, context, topScope, tabulatorClass, fsa)
+			generateTabulator(type, context, topScope, tabulatorClass, fsa)
 		}
 	}
 
@@ -255,9 +254,9 @@ class TabulatorGenerator {
 		}
 	}
 	
-	private def boolean isDataTabulatable(Data data) {
+	private def boolean isDataTabulatable(Data type) {
 		val types = rosettaConfiguration.generators.tabulators.types
-		val fqn = String.format("%s.%s", data.model.name, data.name)
+		val fqn = String.format("%s.%s", type.model.name, type.name)
 		types.contains(fqn)
 	}
 
@@ -273,8 +272,8 @@ class TabulatorGenerator {
 		shouldGenerateLegacyTabulator ? new ProjectionTabulatorContext(typeTranslator, func) : new FunctionTabulatorContext(typeTranslator, func)
 	}
 	
-	private def TabulatorContext createDataTabulatorContext(JavaTypeTranslator typeTranslator, Data data) {
-		new DataTabulatorContext(typeTranslator, data)
+	private def TabulatorContext createDataTabulatorContext(JavaTypeTranslator typeTranslator) {
+		new DataTabulatorContext(typeTranslator)
 	}
 
 	private def JavaClass<Tabulator<?>> toApplicableTabulatorClass(Function func) {

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/reports/TabulatorGenerator.xtend
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/reports/TabulatorGenerator.xtend
@@ -255,9 +255,9 @@ class TabulatorGenerator {
 		}
 	}
 	
-	private def boolean isDataTabulatable(Data type) {
+	private def boolean isDataTabulatable(Data data) {
 		val types = rosettaConfiguration.generators.tabulators.types
-		val fqn = String.format("%s.%s", type.model.name, type.name)
+		val fqn = String.format("%s.%s", data.model.name, data.name)
 		types.contains(fqn)
 	}
 

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/reports/TabulatorGenerator.xtend
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/reports/TabulatorGenerator.xtend
@@ -1,41 +1,41 @@
 package com.regnosys.rosetta.generator.java.reports
 
-import org.eclipse.xtext.generator.IFileSystemAccess2
-import com.regnosys.rosetta.rosetta.simple.Data
-import com.regnosys.rosetta.generator.java.JavaScope
-import javax.inject.Inject
-import com.regnosys.rosetta.generator.java.types.JavaTypeTranslator
-import org.eclipse.xtend2.lib.StringConcatenationClient
-import com.regnosys.rosetta.generator.java.util.ImportManagerExtension
-import com.rosetta.util.types.JavaClass
-import com.rosetta.model.lib.reports.Tabulator
-import com.regnosys.rosetta.types.RDataType
-import com.rosetta.util.DottedPath
-import com.rosetta.model.lib.reports.Tabulator.Field
-import com.rosetta.model.lib.reports.Tabulator.FieldImpl
-import java.util.Optional
-import com.regnosys.rosetta.generator.GeneratedIdentifier
-import java.util.List
-import java.util.Arrays
-import com.rosetta.model.lib.reports.Tabulator.FieldValue
-import java.util.stream.Collectors
-import com.rosetta.model.lib.reports.Tabulator.FieldValueImpl
-import com.regnosys.rosetta.rosetta.simple.Attribute
+import com.google.inject.ImplementedBy
 import com.regnosys.rosetta.RosettaExtensions
+import com.regnosys.rosetta.config.RosettaConfiguration
+import com.regnosys.rosetta.generator.GeneratedIdentifier
+import com.regnosys.rosetta.generator.java.JavaScope
+import com.regnosys.rosetta.generator.java.types.JavaTypeTranslator
+import com.regnosys.rosetta.generator.java.types.JavaTypeUtil
+import com.regnosys.rosetta.generator.java.util.ImportManagerExtension
 import com.regnosys.rosetta.rosetta.RosettaExternalRuleSource
-import java.util.Map
-import com.regnosys.rosetta.types.RosettaTypeProvider
-import java.util.Set
-import org.apache.commons.text.StringEscapeUtils
-import com.rosetta.model.lib.reports.Tabulator.MultiNestedFieldValueImpl
-import com.rosetta.model.lib.reports.Tabulator.NestedFieldValueImpl
-import com.rosetta.model.lib.ModelSymbolId
 import com.regnosys.rosetta.rosetta.RosettaReport
 import com.regnosys.rosetta.rosetta.RosettaRule
-import com.regnosys.rosetta.generator.java.types.JavaTypeUtil
+import com.regnosys.rosetta.rosetta.simple.Attribute
+import com.regnosys.rosetta.rosetta.simple.Data
 import com.regnosys.rosetta.rosetta.simple.Function
-import com.regnosys.rosetta.config.RosettaConfiguration
-import com.google.inject.ImplementedBy
+import com.regnosys.rosetta.types.RDataType
+import com.regnosys.rosetta.types.RosettaTypeProvider
+import com.rosetta.model.lib.ModelSymbolId
+import com.rosetta.model.lib.reports.Tabulator
+import com.rosetta.model.lib.reports.Tabulator.Field
+import com.rosetta.model.lib.reports.Tabulator.FieldImpl
+import com.rosetta.model.lib.reports.Tabulator.FieldValue
+import com.rosetta.model.lib.reports.Tabulator.FieldValueImpl
+import com.rosetta.model.lib.reports.Tabulator.MultiNestedFieldValueImpl
+import com.rosetta.model.lib.reports.Tabulator.NestedFieldValueImpl
+import com.rosetta.util.DottedPath
+import com.rosetta.util.types.JavaClass
+import java.util.Arrays
+import java.util.List
+import java.util.Map
+import java.util.Optional
+import java.util.Set
+import java.util.stream.Collectors
+import javax.inject.Inject
+import org.apache.commons.text.StringEscapeUtils
+import org.eclipse.xtend2.lib.StringConcatenationClient
+import org.eclipse.xtext.generator.IFileSystemAccess2
 
 class TabulatorGenerator {
 	private interface TabulatorContext {
@@ -86,7 +86,6 @@ class TabulatorGenerator {
 		override getFunction() {
 			throw new UnsupportedOperationException("getFunction not available for ReportTabulatorContext")
 		}
-		
 	}
 	@Deprecated
 	@org.eclipse.xtend.lib.annotations.Data
@@ -113,8 +112,6 @@ class TabulatorGenerator {
 		override getFunction() {
 			projection
 		}
-		
-
 	}
 	@org.eclipse.xtend.lib.annotations.Data
 	private static class FunctionTabulatorContext implements TabulatorContext {
@@ -136,7 +133,31 @@ class TabulatorGenerator {
 		override getRule(Attribute attr) {
 			Optional.empty
 		}
+	}
+	@org.eclipse.xtend.lib.annotations.Data
+	private static class DataTabulatorContext implements TabulatorContext {
+		extension JavaTypeTranslator typeTranslator
+		Data data
 
+		override needsTabulator(Data type) {
+			true
+		}
+
+		override isTabulated(Attribute attr) {
+			true
+		}
+
+		override toTabulatorJavaClass(Data type) {
+			typeTranslator.toTabulatorJavaClass(type)
+		}
+
+		override getRule(Attribute attr) {
+			Optional.empty
+		}
+
+		override getFunction() {
+			throw new UnsupportedOperationException("TODO: remove")
+		}
 	}
 	
 	@Inject RosettaTypeProvider typeProvider
@@ -150,7 +171,7 @@ class TabulatorGenerator {
 	def generate(IFileSystemAccess2 fsa, RosettaReport report) {
 		val tabulatorClass = report.toReportTabulatorJavaClass
 		val topScope = new JavaScope(tabulatorClass.packageName)
-		
+
 		val context = getContext(report.reportType, Optional.ofNullable(report.ruleSource))
 		val classBody = report.reportType.mainTabulatorClassBody(context, topScope, tabulatorClass)
 		val content = buildClass(tabulatorClass.packageName, classBody, topScope)
@@ -162,30 +183,46 @@ class TabulatorGenerator {
 		if (context.needsTabulator(type)) {
 			val tabulatorClass = type.toTabulatorJavaClass(ruleSource)
 			val topScope = new JavaScope(tabulatorClass.packageName)
-			
+
 			val classBody = type.tabulatorClassBody(context, topScope, tabulatorClass)
 			val content = buildClass(tabulatorClass.packageName, classBody, topScope)
 			fsa.generateFile(tabulatorClass.canonicalName.withForwardSlashes + ".java", content)
 		}
 	}
 	
+	def generate(IFileSystemAccess2 fsa, Data data) {
+		if (data.isTypeTabulatable) {
+			val context = createDataTabulatorContext(typeTranslator, data)
+
+			val tabulatorClass = data.toTabulatorJavaClass
+			val topScope = new JavaScope(tabulatorClass.packageName)
+
+			generateTabulator(data, context, topScope, tabulatorClass, fsa)
+		}
+	}
+
 	def generate(IFileSystemAccess2 fsa, Function func) {
 		if (func.isFunctionTabulatable) {
 			val tabulatorClass = func.toApplicableTabulatorClass
 			val topScope = new JavaScope(tabulatorClass.packageName)
 			
-			val projectionType = typeProvider.getRTypeOfSymbol(func.output)
-			if (projectionType instanceof RDataType) {
+			val functionOutputType = typeProvider.getRTypeOfSymbol(func.output)
+			if (functionOutputType instanceof RDataType) {
 				val context = createFunctionTabulatorContext(typeTranslator, func)
 				
-				val classBody = projectionType.data.mainTabulatorClassBody(context, topScope, tabulatorClass)
-				val content = buildClass(tabulatorClass.packageName, classBody, topScope)
-				fsa.generateFile(tabulatorClass.canonicalName.withForwardSlashes + ".java", content)
-				
-				recursivelyGenerateFunctionTypeTabulators(fsa, projectionType.data, context, newHashSet)
+				generateTabulator(functionOutputType.data, context, topScope, tabulatorClass, fsa)
 			}
 		}
 	}
+
+	private def void generateTabulator(Data type, TabulatorContext context, JavaScope topScope, JavaClass<Tabulator<?>> tabulatorClass, IFileSystemAccess2 fsa) {
+		val classBody = type.mainTabulatorClassBody(context, topScope, tabulatorClass)
+		val content = buildClass(tabulatorClass.packageName, classBody, topScope)
+		fsa.generateFile(tabulatorClass.canonicalName.withForwardSlashes + ".java", content)
+
+		recursivelyGenerateFunctionTypeTabulators(fsa, type, context, newHashSet)
+	}
+
 	private def void recursivelyGenerateFunctionTypeTabulators(IFileSystemAccess2 fsa, Data type, TabulatorContext context, Set<Data> visited) {
 		if (visited.add(type)) {
 			val tabulatorClass = context.toTabulatorJavaClass(type)
@@ -218,6 +255,12 @@ class TabulatorGenerator {
 		}
 	}
 	
+	private def boolean isTypeTabulatable(Data type) {
+		val types = rosettaConfiguration.generators.tabulators.types
+		val fqn = String.format("%s.%s", type.model.name, type.name)
+		types.contains(fqn)
+	}
+
 	private def boolean isAnnotatedWith(Function func, String with) {
 		func.annotations.findFirst[annotation.name == with] !== null
 	}
@@ -230,6 +273,10 @@ class TabulatorGenerator {
 		shouldGenerateLegacyTabulator ? new ProjectionTabulatorContext(typeTranslator, func) : new FunctionTabulatorContext(typeTranslator, func)
 	}
 	
+	private def TabulatorContext createDataTabulatorContext(JavaTypeTranslator typeTranslator, Data data) {
+		new DataTabulatorContext(typeTranslator, data)
+	}
+
 	private def JavaClass<Tabulator<?>> toApplicableTabulatorClass(Function func) {
 		shouldGenerateLegacyTabulator ? func.toProjectionTabulatorJavaClass : func.toTabulatorJavaClass
 	}

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/types/JavaTypeTranslator.java
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/types/JavaTypeTranslator.java
@@ -175,6 +175,12 @@ public class JavaTypeTranslator extends RosettaTypeSwitch<JavaType, Void> {
 		String simpleName = typeId.getName() + function.getName() + "TypeTabulator";
 		return new GeneratedJavaClass<>(packageName, simpleName, new com.fasterxml.jackson.core.type.TypeReference<Tabulator<?>>() {});
 	}
+	public JavaClass<Tabulator<?>> toTabulatorJavaClass(Data type) {
+		ModelSymbolId typeId = getSymbolId(type);
+		DottedPath packageName = typeId.getNamespace().child("tabulator");
+		String simpleName = typeId.getName() + "TypeTabulator";
+		return new GeneratedJavaClass<>(packageName, simpleName, new com.fasterxml.jackson.core.type.TypeReference<Tabulator<?>>() {});
+	}
 	public JavaClass<?> toDeepPathUtilJavaClass(Data choiceType) {
 		ModelSymbolId typeId = getSymbolId(choiceType);
 		DottedPath packageName = typeId.getNamespace().child("util");

--- a/rosetta-testing/src/main/java/com/regnosys/rosetta/tests/util/CustomConfigTestHelper.xtend
+++ b/rosetta-testing/src/main/java/com/regnosys/rosetta/tests/util/CustomConfigTestHelper.xtend
@@ -36,7 +36,7 @@ class CustomConfigTestHelper {
 
 	static private def Injector getInjector(Class<? extends RosettaConfigurationFileProvider> configurationFileProvider) {
 		val provider = createProvider(configurationFileProvider)
-		provider.injector
+		provider.getInjector
 	}
 
 	static private def RosettaCustomConfigInjectorProvider createProvider(

--- a/rosetta-testing/src/main/java/com/regnosys/rosetta/tests/util/CustomConfigTestHelper.xtend
+++ b/rosetta-testing/src/main/java/com/regnosys/rosetta/tests/util/CustomConfigTestHelper.xtend
@@ -1,0 +1,61 @@
+package com.regnosys.rosetta.tests.util
+
+import com.regnosys.rosetta.config.file.RosettaConfigurationFileProvider
+import java.util.List
+import java.util.HashMap
+import com.google.inject.Injector
+import com.regnosys.rosetta.RosettaRuntimeModule
+import com.regnosys.rosetta.tests.RosettaInjectorProvider
+
+class CustomConfigTestHelper {
+	def compileToClassesForModel(List<HashMap<String, String>> code,
+		Class<? extends RosettaConfigurationFileProvider> configurationFileProvider) {
+		val codeGeneratorTestHelper = getCodeGeneratorTestHelper(configurationFileProvider)
+		val generatedCode = newHashMap
+		code.forEach[it.forEach[k, v|generatedCode.put(k, v)]]
+		codeGeneratorTestHelper.compileToClasses(generatedCode)
+	}
+
+	def generateCodeForModel(CharSequence model,
+		Class<? extends RosettaConfigurationFileProvider> configurationFileProvider) {
+		val codeGeneratorTestHelper = getCodeGeneratorTestHelper(configurationFileProvider)
+		codeGeneratorTestHelper.generateCode(model)
+	}
+
+	def generateCodeForModel(List<? extends CharSequence> models,
+		Class<? extends RosettaConfigurationFileProvider> configurationFileProvider) {
+		val codeGeneratorTestHelper = getCodeGeneratorTestHelper(configurationFileProvider)
+		codeGeneratorTestHelper.generateCode(models)
+	}
+
+	private def CodeGeneratorTestHelper getCodeGeneratorTestHelper(
+		Class<? extends RosettaConfigurationFileProvider> configurationFileProvider) {
+		val injector = getInjector(configurationFileProvider)
+		injector.getInstance(CodeGeneratorTestHelper)
+	}
+
+	private def Injector getInjector(Class<? extends RosettaConfigurationFileProvider> configurationFileProvider) {
+		val provider = createProvider(configurationFileProvider)
+		provider.injector
+	}
+
+	private def RosettaCustomConfigInjectorProvider createProvider(
+		Class<? extends RosettaConfigurationFileProvider> configurationFileProvider) {
+
+		new RosettaCustomConfigInjectorProvider() {
+
+			override RosettaRuntimeModule createRuntimeModule() {
+
+				new RosettaRuntimeModule() {
+					override ClassLoader bindClassLoaderToInstance() {
+						RosettaInjectorProvider.getClassLoader()
+					}
+
+					def Class<? extends RosettaConfigurationFileProvider> bindRosettaConfigurationFileProvider() {
+						return configurationFileProvider
+					}
+				}
+			}
+		}
+	}
+}

--- a/rosetta-testing/src/main/java/com/regnosys/rosetta/tests/util/CustomConfigTestHelper.xtend
+++ b/rosetta-testing/src/main/java/com/regnosys/rosetta/tests/util/CustomConfigTestHelper.xtend
@@ -8,7 +8,7 @@ import com.regnosys.rosetta.RosettaRuntimeModule
 import com.regnosys.rosetta.tests.RosettaInjectorProvider
 
 class CustomConfigTestHelper {
-	def compileToClassesForModel(List<HashMap<String, String>> code,
+	static def compileToClassesForModel(List<HashMap<String, String>> code,
 		Class<? extends RosettaConfigurationFileProvider> configurationFileProvider) {
 		val codeGeneratorTestHelper = getCodeGeneratorTestHelper(configurationFileProvider)
 		val generatedCode = newHashMap
@@ -16,30 +16,30 @@ class CustomConfigTestHelper {
 		codeGeneratorTestHelper.compileToClasses(generatedCode)
 	}
 
-	def generateCodeForModel(CharSequence model,
+	static def generateCodeForModel(CharSequence model,
 		Class<? extends RosettaConfigurationFileProvider> configurationFileProvider) {
 		val codeGeneratorTestHelper = getCodeGeneratorTestHelper(configurationFileProvider)
 		codeGeneratorTestHelper.generateCode(model)
 	}
 
-	def generateCodeForModel(List<? extends CharSequence> models,
+	static def generateCodeForModel(List<? extends CharSequence> models,
 		Class<? extends RosettaConfigurationFileProvider> configurationFileProvider) {
 		val codeGeneratorTestHelper = getCodeGeneratorTestHelper(configurationFileProvider)
 		codeGeneratorTestHelper.generateCode(models)
 	}
 
-	private def CodeGeneratorTestHelper getCodeGeneratorTestHelper(
+	static private def CodeGeneratorTestHelper getCodeGeneratorTestHelper(
 		Class<? extends RosettaConfigurationFileProvider> configurationFileProvider) {
 		val injector = getInjector(configurationFileProvider)
 		injector.getInstance(CodeGeneratorTestHelper)
 	}
 
-	private def Injector getInjector(Class<? extends RosettaConfigurationFileProvider> configurationFileProvider) {
+	static private def Injector getInjector(Class<? extends RosettaConfigurationFileProvider> configurationFileProvider) {
 		val provider = createProvider(configurationFileProvider)
 		provider.injector
 	}
 
-	private def RosettaCustomConfigInjectorProvider createProvider(
+	static private def RosettaCustomConfigInjectorProvider createProvider(
 		Class<? extends RosettaConfigurationFileProvider> configurationFileProvider) {
 
 		new RosettaCustomConfigInjectorProvider() {

--- a/rosetta-testing/src/main/java/com/regnosys/rosetta/tests/util/RosettaCustomConfigInjectorProvider.java
+++ b/rosetta-testing/src/main/java/com/regnosys/rosetta/tests/util/RosettaCustomConfigInjectorProvider.java
@@ -1,4 +1,4 @@
-package com.regnosys.rosetta.config;
+package com.regnosys.rosetta.tests.util;
 
 import java.net.URL;
 

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/object/ConfigurableTypeTabulatorTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/object/ConfigurableTypeTabulatorTest.xtend
@@ -8,17 +8,7 @@ import java.net.URL
 import static org.junit.jupiter.api.Assertions.*
 import static org.hamcrest.MatcherAssert.*
 import org.hamcrest.CoreMatchers
-import com.regnosys.rosetta.tests.RosettaInjectorProvider
-import org.eclipse.xtext.testing.extensions.InjectionExtension
-import org.eclipse.xtext.testing.InjectWith
-import org.junit.jupiter.api.^extension.ExtendWith
-import javax.inject.Inject
-import com.regnosys.rosetta.tests.util.CodeGeneratorTestHelper
-import com.rosetta.util.types.generated.GeneratedJavaClassService
-import com.regnosys.rosetta.generator.java.reports.TabulatorTestUtil
 
-@InjectWith(RosettaInjectorProvider)
-@ExtendWith(InjectionExtension)
 class ConfigurableTypeTabulatorTest {
 		
 	@Test

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/object/ConfigurableTypeTabulatorTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/object/ConfigurableTypeTabulatorTest.xtend
@@ -1,0 +1,94 @@
+package com.regnosys.rosetta.generator.java.object
+
+import org.junit.jupiter.api.Test
+import com.regnosys.rosetta.config.file.RosettaConfigurationFileProvider
+
+import static extension com.regnosys.rosetta.tests.util.CustomConfigTestHelper.*
+import java.net.URL
+import static org.junit.jupiter.api.Assertions.*
+import static org.hamcrest.MatcherAssert.*
+import org.hamcrest.CoreMatchers
+import com.regnosys.rosetta.tests.RosettaInjectorProvider
+import org.eclipse.xtext.testing.extensions.InjectionExtension
+import org.eclipse.xtext.testing.InjectWith
+import org.junit.jupiter.api.^extension.ExtendWith
+import javax.inject.Inject
+import com.regnosys.rosetta.tests.util.CodeGeneratorTestHelper
+import com.rosetta.util.types.generated.GeneratedJavaClassService
+import com.regnosys.rosetta.generator.java.reports.TabulatorTestUtil
+
+@InjectWith(RosettaInjectorProvider)
+@ExtendWith(InjectionExtension)
+class ConfigurableTypeTabulatorTest {
+		
+	@Test
+	def void shouldGenerateTabulatorsForTypeListedInConfig() {
+		val model1 = '''
+			namespace model1
+			
+				type Foo:
+				   bar Bar (1..1)
+				
+				type Bar:
+				   baz string (1..1)
+		'''
+
+		val model1Code = model1.generateCodeForModel(Model1FileConfigProvider)
+		val fooTabulatorCode = model1Code.get("model1.tabulator.FooTypeTabulator")
+		assertThat(fooTabulatorCode, CoreMatchers.notNullValue())
+		var expected = '''
+			package model1.tabulator;
+			
+			import com.google.inject.ImplementedBy;
+			import com.rosetta.model.lib.reports.Tabulator;
+			import com.rosetta.model.lib.reports.Tabulator.Field;
+			import com.rosetta.model.lib.reports.Tabulator.FieldImpl;
+			import com.rosetta.model.lib.reports.Tabulator.FieldValue;
+			import com.rosetta.model.lib.reports.Tabulator.NestedFieldValueImpl;
+			import java.util.Arrays;
+			import java.util.List;
+			import java.util.Optional;
+			import javax.inject.Inject;
+			import model1.Foo;
+			
+			
+			@ImplementedBy(FooTypeTabulator.Impl.class)
+			public interface FooTypeTabulator extends Tabulator<Foo> {
+				public class Impl implements FooTypeTabulator {
+					private final Field barField;
+					
+					private final BarTypeTabulator barTypeTabulator;
+					
+					@Inject
+					public Impl(BarTypeTabulator barTypeTabulator) {
+						this.barTypeTabulator = barTypeTabulator;
+						this.barField = new FieldImpl(
+							"bar",
+							false,
+							Optional.empty(),
+							Optional.empty(),
+							Arrays.asList()
+						);
+					}
+					
+					@Override
+					public List<FieldValue> tabulate(Foo input) {
+						FieldValue bar = Optional.ofNullable(input.getBar())
+							.map(x -> new NestedFieldValueImpl(barField, Optional.of(barTypeTabulator.tabulate(x))))
+							.orElse(new NestedFieldValueImpl(barField, Optional.empty()));
+						return Arrays.asList(
+							bar
+						);
+					}
+				}
+			}
+		'''
+		assertEquals(expected, fooTabulatorCode)
+	}
+	
+	private static class Model1FileConfigProvider extends RosettaConfigurationFileProvider {
+		override URL get() {
+			Thread.currentThread.contextClassLoader.getResource("rosetta-tabulator-type-config-model1.yml")
+		}
+	}
+}

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/object/ModelMetaGeneratorFilteredNamespaceTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/object/ModelMetaGeneratorFilteredNamespaceTest.xtend
@@ -1,15 +1,9 @@
 package com.regnosys.rosetta.generator.java.object
 
-import com.google.inject.Injector
-import com.regnosys.rosetta.RosettaRuntimeModule
-import com.regnosys.rosetta.config.RosettaCustomConfigInjectorProvider
 import com.regnosys.rosetta.config.file.RosettaConfigurationFileProvider
-import com.regnosys.rosetta.tests.RosettaInjectorProvider
-import com.regnosys.rosetta.tests.util.CodeGeneratorTestHelper
 import java.net.URL
-import java.util.HashMap
-import java.util.List
 import org.junit.jupiter.api.Test
+import static extension com.regnosys.rosetta.tests.util.CustomConfigTestHelper
 
 class ModelMetaGeneratorFilteredNamespaceTest {
 
@@ -36,57 +30,6 @@ class ModelMetaGeneratorFilteredNamespaceTest {
 		val model2Code = #[model1, model2].generateCodeForModel(Model2FileConfigProvider)
 
 		#[model1Code, model2Code].compileToClassesForModel(Model2FileConfigProvider)
-	}
-
-	def compileToClassesForModel(List<HashMap<String, String>> code,
-		Class<? extends RosettaConfigurationFileProvider> configurationFileProvider) {
-		val codeGeneratorTestHelper = getCodeGeneratorTestHelper(configurationFileProvider)
-		val generatedCode = newHashMap
-		code.forEach[it.forEach[k, v|generatedCode.put(k, v)]]
-		codeGeneratorTestHelper.compileToClasses(generatedCode)
-	}
-
-	def generateCodeForModel(CharSequence model,
-		Class<? extends RosettaConfigurationFileProvider> configurationFileProvider) {
-		val codeGeneratorTestHelper = getCodeGeneratorTestHelper(configurationFileProvider)
-		codeGeneratorTestHelper.generateCode(model)
-	}
-
-	def generateCodeForModel(List<? extends CharSequence> models,
-		Class<? extends RosettaConfigurationFileProvider> configurationFileProvider) {
-		val codeGeneratorTestHelper = getCodeGeneratorTestHelper(configurationFileProvider)
-		codeGeneratorTestHelper.generateCode(models)
-	}
-
-	def CodeGeneratorTestHelper getCodeGeneratorTestHelper(
-		Class<? extends RosettaConfigurationFileProvider> configurationFileProvider) {
-		val injector = getInjector(configurationFileProvider)
-		injector.getInstance(CodeGeneratorTestHelper)
-	}
-
-	def Injector getInjector(Class<? extends RosettaConfigurationFileProvider> configurationFileProvider) {
-		val provider = createProvider(configurationFileProvider)
-		provider.injector
-	}
-
-	def RosettaCustomConfigInjectorProvider createProvider(
-		Class<? extends RosettaConfigurationFileProvider> configurationFileProvider) {
-
-		new RosettaCustomConfigInjectorProvider() {
-
-			override RosettaRuntimeModule createRuntimeModule() {
-
-				new RosettaRuntimeModule() {
-					override ClassLoader bindClassLoaderToInstance() {
-						RosettaInjectorProvider.getClassLoader()
-					}
-
-					def Class<? extends RosettaConfigurationFileProvider> bindRosettaConfigurationFileProvider() {
-						return configurationFileProvider
-					}
-				}
-			}
-		}
 	}
 
 	private static class Model1FileConfigProvider extends RosettaConfigurationFileProvider {

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/object/ModelMetaGeneratorFilteredNamespaceTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/object/ModelMetaGeneratorFilteredNamespaceTest.xtend
@@ -3,7 +3,7 @@ package com.regnosys.rosetta.generator.java.object
 import com.regnosys.rosetta.config.file.RosettaConfigurationFileProvider
 import java.net.URL
 import org.junit.jupiter.api.Test
-import static extension com.regnosys.rosetta.tests.util.CustomConfigTestHelper
+import static extension com.regnosys.rosetta.tests.util.CustomConfigTestHelper.*
 
 class ModelMetaGeneratorFilteredNamespaceTest {
 

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/object/ModelMetaGeneratorFilteredNamespaceTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/object/ModelMetaGeneratorFilteredNamespaceTest.xtend
@@ -3,6 +3,7 @@ package com.regnosys.rosetta.generator.java.object
 import com.regnosys.rosetta.config.file.RosettaConfigurationFileProvider
 import java.net.URL
 import org.junit.jupiter.api.Test
+
 import static extension com.regnosys.rosetta.tests.util.CustomConfigTestHelper.*
 
 class ModelMetaGeneratorFilteredNamespaceTest {

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/reports/ConfigurableTabulatorTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/reports/ConfigurableTabulatorTest.xtend
@@ -1,7 +1,7 @@
 package com.regnosys.rosetta.generator.java.reports
 
-import com.regnosys.rosetta.config.RosettaCustomConfigInjectorProvider
 import com.regnosys.rosetta.tests.util.CodeGeneratorTestHelper
+import com.regnosys.rosetta.tests.util.RosettaCustomConfigInjectorProvider
 import com.rosetta.model.lib.RosettaModelObject
 import com.rosetta.model.lib.reports.Tabulator
 import com.rosetta.util.DottedPath
@@ -12,8 +12,8 @@ import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.extensions.InjectionExtension
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.^extension.ExtendWith
-import static org.junit.jupiter.api.Assertions.*
 
+import static org.junit.jupiter.api.Assertions.assertNotNull
 
 @InjectWith(RosettaCustomConfigInjectorProvider)
 @ExtendWith(InjectionExtension)

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/reports/TabulatorCircularDependencyTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/reports/TabulatorCircularDependencyTest.xtend
@@ -1,7 +1,7 @@
 package com.regnosys.rosetta.generator.java.reports
 
-import com.regnosys.rosetta.config.RosettaCustomConfigInjectorProvider
 import com.regnosys.rosetta.tests.util.CodeGeneratorTestHelper
+import com.regnosys.rosetta.tests.util.RosettaCustomConfigInjectorProvider
 import javax.inject.Inject
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.extensions.InjectionExtension

--- a/rosetta-testing/src/test/resources/rosetta-tabulator-type-config-model1.yml
+++ b/rosetta-testing/src/test/resources/rosetta-tabulator-type-config-model1.yml
@@ -1,0 +1,11 @@
+model:
+  name: My test model
+dependencies:
+generators:
+  namespaces:
+  - model1.*
+  tabulators:
+    annotations:
+    types:
+    - model1.Foo
+    - model1.Bar


### PR DESCRIPTION
Allow DSL users to configure tabulators to be generated for specified types. E.g.:

```
model:
  name: My test model
dependencies:
generators:
  namespaces:
  - model1.*
  tabulators:
    annotations:
    types:
    - model1.Foo
    - model1.Bar
```
## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)