### PR TITLE
story 959 task-5036: bug fix

### DIFF
--- a/rosetta-runtime/src/main/java/com/rosetta/model/lib/reports/Tabulator.java
+++ b/rosetta-runtime/src/main/java/com/rosetta/model/lib/reports/Tabulator.java
@@ -150,7 +150,7 @@ public interface Tabulator<T> {
 		}
 		@Override
 		public String toString() {
-			return String.format("<%s, %s, alreadyReferenced [%b], referencedField [%s]>", field.getName(), value.map(Object::toString).orElse("<empty>"));
+			return String.format("<%s, %s>", field.getName(), value.map(Object::toString).orElse("<empty>"));
 		}
 		@Override
 		public int hashCode() {

--- a/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/reports/TabulatorTest.xtend
+++ b/rosetta-testing/src/test/java/com/regnosys/rosetta/generator/java/reports/TabulatorTest.xtend
@@ -730,4 +730,34 @@ class TabulatorTest {
 		'''
 		assertFieldValuesEqual(expectedValues, flatReport)
 	}
+	
+	@Test
+	def void confirmToString() {
+		val model = '''
+			«HEADER»
+			
+			type ReportableInput:
+				title string (1..1)
+			
+			type Report:
+				basic string (1..1)
+					[ruleReference Basic]
+			
+			
+			reporting rule Basic from ReportableInput:
+				extract title
+		'''
+		val code = model.generateCode
+		
+		val reportId = new ModelReportId(DottedPath.splitOnDots("com.rosetta.test.model"), "TEST_REG", "Corp")
+		val tabulatorClass = reportId.toJavaReportTabulator
+		val classes = code.compileToClasses
+		val tabulator = classes.<Tabulator<RosettaModelObject>>createInstance(tabulatorClass)
+		val report = classes.createInstanceUsingBuilder("Report", #{"basic" -> "My reportable input"})
+		val actual = tabulator.tabulate(report)
+		
+		val expected = "[<basic, My reportable input>]"
+		
+		assertEquals(actual.toString(), expected)
+	}
 }


### PR DESCRIPTION
story 959 task-5036: bug fix - old string parameter left in place

Causing the following error: 
```
java.util.MissingFormatArgumentException: Format specifier '%b'
	at java.base/java.util.Formatter.format(Formatter.java:2672)
	at java.base/java.util.Formatter.format(Formatter.java:2609)
	at java.base/java.lang.String.format(String.java:2897)
	at com.rosetta.model.lib.reports.Tabulator$FieldValueImpl.toString(Tabulator.java:154)
	at java.base/java.lang.String.valueOf(String.java:2951)
	at java.base/java.lang.StringBuilder.append(StringBuilder.java:168)
	at java.base/java.util.AbstractCollection.toString(AbstractCollection.java:473)
	at com.regnosys.rosetta.generator.java.reports.TabulatorTest.confirmToString(TabulatorTest.java:1533)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)
