### PR TITLE
Story/3511/with meta address and location

### DIFF
--- a/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorMetaTest.java
+++ b/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorMetaTest.java
@@ -27,12 +27,73 @@ public class FunctionGeneratorMetaTest {
     FunctionGeneratorHelper functionGeneratorHelper;
     @Inject
     CodeGeneratorTestHelper generatorTestHelper;
-    
-    //TODO:canSetMetaLocationOnFunctionBasicOutput
-    
+        
+    @Test
+    void canSetMetaLocationOnFunctionBasicOutput() {
+        var model = """
+        metaType location string
+
+        func MyFunc:
+            output:
+                result string (1..1)
+                    [metadata location]
+            set result:  "someValue"
+            set result -> location: "someAddress"
+       """;
+
+        var code = generatorTestHelper.generateCode(model);
+        
+        var classes = generatorTestHelper.compileToClasses(code);
+        var myFunc = functionGeneratorHelper.createFunc(classes, "MyFunc");
+
+        var result = functionGeneratorHelper.invokeFunc(myFunc, FieldWithMeta.class);
+        
+        var expected = generatorTestHelper.createInstanceUsingBuilder(classes, new RosettaJavaPackages.RootPackage("com.rosetta.model.metafields"), "FieldWithMetaString", Map.of(
+                "value", "someValue",
+                "meta", MetaFields.builder().setLocation("someAddress")
+        ));
+
+        assertEquals(expected, result);    	
+    }
     
     @Test
-    void canSetMetaAddressOnFunctionBasicOutput() {
+    void canSetMetaAddressOnFunctionObjectOutput() {
+        var model = """
+        metaType address string
+        
+        type Foo:
+            field string (1..1)
+
+        func MyFunc:
+            output:
+                result Foo (1..1)
+                    [metadata address]
+            set result -> field:  "someValue"
+            set result -> address: "someLocation"
+       """;
+
+        var code = generatorTestHelper.generateCode(model);
+        
+        generatorTestHelper.writeClasses(code, "canSetMetaAddressOnFunctionObjectOutput");
+
+        var classes = generatorTestHelper.compileToClasses(code);        
+        
+        var myFunc = functionGeneratorHelper.createFunc(classes, "MyFunc");
+
+        var result = functionGeneratorHelper.invokeFunc(myFunc, FieldWithMeta.class);
+        
+        var expected = generatorTestHelper.createInstanceUsingBuilder(classes, new RosettaJavaPackages.RootPackage("com.rosetta.test.model.metafields"), "ReferenceWithMetaFoo", Map.of(
+                "value", generatorTestHelper.createInstanceUsingBuilder(classes, new RosettaJavaPackages.RootPackage("com.rosetta.test.model"), "Foo", Map.of(
+                			"field", "someValue"
+                		)),
+                "reference", Reference.builder().setReference("someLocation")
+        ));
+
+        assertEquals(expected, result);    
+    }  
+    
+    @Test
+    void canSetAddressOnFunctionBasicOutput() {
         var model = """
         metaType address string
 
@@ -45,7 +106,7 @@ public class FunctionGeneratorMetaTest {
        """;
 
         var code = generatorTestHelper.generateCode(model);
-
+        
         var classes = generatorTestHelper.compileToClasses(code);
         
         
@@ -63,7 +124,7 @@ public class FunctionGeneratorMetaTest {
     
     
     @Test
-    void canSetExternalIdOnFunctionObjectOutput() {
+    void canSetExternalIdOnFunctionBasicOutput() {
         var model = """
         metaType id string
         
@@ -139,7 +200,7 @@ public class FunctionGeneratorMetaTest {
         """;
 
         var code = generatorTestHelper.generateCode(model);
-        
+                
         var classes = generatorTestHelper.compileToClasses(code);
         var myFunc = functionGeneratorHelper.createFunc(classes, "MyFunc");
 
@@ -154,7 +215,7 @@ public class FunctionGeneratorMetaTest {
 
     @Disabled  //TODO: implement setting nested meta
     @Test
-    void canSetMetaOnFunctionObjectOutputAndNestedMetaField() {
+    void canSetMetaOnFunctionObjectOutputAndNestedBasicMetaField() {
         var model = """
         type Foo:
             a string (1..1)
@@ -192,7 +253,7 @@ public class FunctionGeneratorMetaTest {
     }
 
     @Test
-    void canSetMetaSchemeOnFunctionObjectOutput() {
+    void canSetSchemeOnFunctionObjectOutput() {
         var model = """
         type Foo:
             a string (1..1)
@@ -225,7 +286,7 @@ public class FunctionGeneratorMetaTest {
     }
 
     @Test
-    void canSetMetaSchemeOnFunctionBasicOutput() {
+    void canSetSchemeOnFunctionBasicOutput() {
         var model = """
         func MyFunc:
             output:


### PR DESCRIPTION
This PR implements the ability to set `address` and `location` references using the `set`/`add` operators as outlined in the first section of https://github.com/finos/rune-dsl/issues/847
