### PR TITLE
Story/3511 setting meta in nested objects

### DIFF
--- a/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorMetaTest.java
+++ b/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorMetaTest.java
@@ -27,12 +27,73 @@ public class FunctionGeneratorMetaTest {
     FunctionGeneratorHelper functionGeneratorHelper;
     @Inject
     CodeGeneratorTestHelper generatorTestHelper;
-    
-    //TODO:canSetMetaLocationOnFunctionBasicOutput
-    
+        
+    @Test
+    void canSetMetaLocationOnFunctionBasicOutput() {
+        var model = """
+        metaType location string
+
+        func MyFunc:
+            output:
+                result string (1..1)
+                    [metadata location]
+            set result:  "someValue"
+            set result -> location: "someAddress"
+       """;
+
+        var code = generatorTestHelper.generateCode(model);
+        
+        var classes = generatorTestHelper.compileToClasses(code);
+        var myFunc = functionGeneratorHelper.createFunc(classes, "MyFunc");
+
+        var result = functionGeneratorHelper.invokeFunc(myFunc, FieldWithMeta.class);
+        
+        var expected = generatorTestHelper.createInstanceUsingBuilder(classes, new RosettaJavaPackages.RootPackage("com.rosetta.model.metafields"), "FieldWithMetaString", Map.of(
+                "value", "someValue",
+                "meta", MetaFields.builder().setLocation("someAddress")
+        ));
+
+        assertEquals(expected, result);    	
+    }
     
     @Test
-    void canSetMetaAddressOnFunctionBasicOutput() {
+    void canSetMetaAddressOnFunctionObjectOutput() {
+        var model = """
+        metaType address string
+        
+        type Foo:
+            field string (1..1)
+
+        func MyFunc:
+            output:
+                result Foo (1..1)
+                    [metadata address]
+            set result -> field:  "someValue"
+            set result -> address: "someLocation"
+       """;
+
+        var code = generatorTestHelper.generateCode(model);
+        
+        generatorTestHelper.writeClasses(code, "canSetMetaAddressOnFunctionObjectOutput");
+
+        var classes = generatorTestHelper.compileToClasses(code);        
+        
+        var myFunc = functionGeneratorHelper.createFunc(classes, "MyFunc");
+
+        var result = functionGeneratorHelper.invokeFunc(myFunc, FieldWithMeta.class);
+        
+        var expected = generatorTestHelper.createInstanceUsingBuilder(classes, new RosettaJavaPackages.RootPackage("com.rosetta.test.model.metafields"), "ReferenceWithMetaFoo", Map.of(
+                "value", generatorTestHelper.createInstanceUsingBuilder(classes, new RosettaJavaPackages.RootPackage("com.rosetta.test.model"), "Foo", Map.of(
+                			"field", "someValue"
+                		)),
+                "reference", Reference.builder().setReference("someLocation")
+        ));
+
+        assertEquals(expected, result);    
+    }  
+    
+    @Test
+    void canSetAddressOnFunctionBasicOutput() {
         var model = """
         metaType address string
 
@@ -45,7 +106,7 @@ public class FunctionGeneratorMetaTest {
        """;
 
         var code = generatorTestHelper.generateCode(model);
-
+        
         var classes = generatorTestHelper.compileToClasses(code);
         
         
@@ -63,7 +124,7 @@ public class FunctionGeneratorMetaTest {
     
     
     @Test
-    void canSetExternalIdOnFunctionObjectOutput() {
+    void canSetExternalIdOnFunctionBasicOutput() {
         var model = """
         metaType id string
         
@@ -139,7 +200,7 @@ public class FunctionGeneratorMetaTest {
         """;
 
         var code = generatorTestHelper.generateCode(model);
-        
+                
         var classes = generatorTestHelper.compileToClasses(code);
         var myFunc = functionGeneratorHelper.createFunc(classes, "MyFunc");
 
@@ -154,7 +215,7 @@ public class FunctionGeneratorMetaTest {
 
     @Disabled  //TODO: implement setting nested meta
     @Test
-    void canSetMetaOnFunctionObjectOutputAndNestedMetaField() {
+    void canSetMetaOnFunctionObjectOutputAndNestedBasicMetaField() {
         var model = """
         type Foo:
             a string (1..1)
@@ -192,7 +253,7 @@ public class FunctionGeneratorMetaTest {
     }
 
     @Test
-    void canSetMetaSchemeOnFunctionObjectOutput() {
+    void canSetSchemeOnFunctionObjectOutput() {
         var model = """
         type Foo:
             a string (1..1)
@@ -225,7 +286,7 @@ public class FunctionGeneratorMetaTest {
     }
 
     @Test
-    void canSetMetaSchemeOnFunctionBasicOutput() {
+    void canSetSchemeOnFunctionBasicOutput() {
         var model = """
         func MyFunc:
             output:

--- a/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorMetaTest.java
+++ b/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorMetaTest.java
@@ -262,14 +262,7 @@ public class FunctionGeneratorMetaTest {
             set result -> b -> scheme: "innerScheme"
         """;
 
-        // set result -> b -> scheme: "innerScheme"
-        //result.getOrCreateValue().getOrCreateB().getOrCreateMeta().setScheme("innerScheme")
-        
-        // set result -> b: "someValueB"
-        //result.getOrCreateValue().setBValue("someValueB")
-
         var code = generatorTestHelper.generateCode(model);
-        generatorTestHelper.writeClasses(code, "canSetMetaOnFunctionObjectOutputAndNestedBasicMetaField");
         
         var classes = generatorTestHelper.compileToClasses(code);
         var myFunc = functionGeneratorHelper.createFunc(classes, "MyFunc");

--- a/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorMetaTest.java
+++ b/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorMetaTest.java
@@ -107,8 +107,6 @@ public class FunctionGeneratorMetaTest {
 
         var code = generatorTestHelper.generateCode(model);
         
-        generatorTestHelper.writeClasses(code, "canSetMetaAddressOnFunctionObjectOutput");
-
         var classes = generatorTestHelper.compileToClasses(code);        
         
         var myFunc = functionGeneratorHelper.createFunc(classes, "MyFunc");
@@ -231,7 +229,7 @@ public class FunctionGeneratorMetaTest {
                   [metadata reference]
             set result -> reference: myKey
         """;
-
+        
         var code = generatorTestHelper.generateCode(model);
                 
         var classes = generatorTestHelper.compileToClasses(code);
@@ -246,10 +244,9 @@ public class FunctionGeneratorMetaTest {
         assertEquals(expected, result);
     }
 
-    @Disabled  //TODO: implement setting nested meta
     @Test
     void canSetMetaOnFunctionObjectOutputAndNestedBasicMetaField() {
-        var model = """
+        var model = """       
         type Foo:
             a string (1..1)
             b string (1..1)
@@ -265,7 +262,15 @@ public class FunctionGeneratorMetaTest {
             set result -> b -> scheme: "innerScheme"
         """;
 
+        // set result -> b -> scheme: "innerScheme"
+        //result.getOrCreateValue().getOrCreateB().getOrCreateMeta().setScheme("innerScheme")
+        
+        // set result -> b: "someValueB"
+        //result.getOrCreateValue().setBValue("someValueB")
+
         var code = generatorTestHelper.generateCode(model);
+        generatorTestHelper.writeClasses(code, "canSetMetaOnFunctionObjectOutputAndNestedBasicMetaField");
+        
         var classes = generatorTestHelper.compileToClasses(code);
         var myFunc = functionGeneratorHelper.createFunc(classes, "MyFunc");
 

--- a/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorMetaTest.java
+++ b/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorMetaTest.java
@@ -186,7 +186,7 @@ public class FunctionGeneratorMetaTest {
     }
    
 
-    @Disabled //TODO: implement nested setting of meta and then complete this
+    @Disabled //TODO: is this syntax needed? if so we need to find a way to get key as a feature from a Data type
     @Test
     void canSetExternalKeyOnFunctionObjectOutput() {
         var model = """
@@ -209,7 +209,7 @@ public class FunctionGeneratorMetaTest {
         
       var code = generatorTestHelper.generateCode(model);
     }
-
+    
     @Test
     void canSetExternalReferenceOnFunctionObjectOutput() {
         var model = """

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/function/FunctionGenerator.xtend
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/function/FunctionGenerator.xtend
@@ -495,7 +495,7 @@ class FunctionGenerator {
 		}
 	}
 	
-	def String getPropertySetterName(JavaType outputExpressionType, JavaPojoProperty prop, RFeature segment) {
+	private def String getPropertySetterName(JavaType outputExpressionType, JavaPojoProperty prop, RFeature segment) {
 		if (outputExpressionType instanceof RJavaWithMetaValue) {
 			segment.toPojoPropertyNames.toFirstUpper
 		} else {
@@ -503,7 +503,7 @@ class FunctionGenerator {
 		}
 	}
 	
-	def boolean requiresValueSetter(JavaType outputExpressionType, JavaPojoProperty outerPojoProperty, RFeature segment, ROperation op) {
+	private def boolean requiresValueSetter(JavaType outputExpressionType, JavaPojoProperty outerPojoProperty, RFeature segment, ROperation op) {
 		val outerPropertyType = outerPojoProperty.type.itemType
 		val innerProp = if (outputExpressionType instanceof RJavaWithMetaValue && outerPropertyType instanceof JavaPojoInterface) {
 			findPojoProperty(segment, outerPropertyType)
@@ -513,16 +513,6 @@ class FunctionGenerator {
 		
 		val innerPropType = innerProp.type.itemType
 		innerPropType instanceof RJavaWithMetaValue && !op.assignAsKey
-	}
-	
-	def JavaPojoProperty createInnerProp(JavaPojoProperty outerPojoProperty, RFeature segment) {
-		val outerPropertyType = outerPojoProperty.type.itemType
-		if (outerPropertyType instanceof JavaPojoInterface) {
-			findPojoProperty(segment, outerPropertyType)
-		} else {
-			outerPojoProperty
-		}
-		
 	}
 	
 	private def StringConcatenationClient generateMetaWrapperCreator(RFeature seg, JavaPojoProperty prop, JavaType expressionType) {

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/function/FunctionGenerator.xtend
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/function/FunctionGenerator.xtend
@@ -464,7 +464,7 @@ class FunctionGenerator {
 							expr = JavaExpression.from('''«metaExpr».getOrCreateValue()''', (expr.expressionType.itemType as RJavaWithMetaValue).valueType)							
 						}
 						
-						val prop = findPojoProperty(seg, expr.expressionType.itemType)
+						val prop = getPojoProperty(seg, expr.expressionType.itemType)
 						val oldExpr = expr
 						val itemType = prop.type.itemType
 						expr = JavaExpression.from(
@@ -479,7 +479,7 @@ class FunctionGenerator {
 					val seg = op.pathTail.get(op.pathTail.length - 1)
 					val oldExpr = expr				
 					val outputExpressionType = expr.expressionType.itemType
-					val prop = findPojoProperty(seg, outputExpressionType)
+					val prop = getPojoProperty(seg, outputExpressionType)
 					
 					val propertySetterName = getPropertySetterName(outputExpressionType, prop, seg)
 					val requiresValueSetter = requiresValueSetter(outputExpressionType, prop, seg, op)
@@ -506,7 +506,7 @@ class FunctionGenerator {
 	private def boolean requiresValueSetter(JavaType outputExpressionType, JavaPojoProperty outerPojoProperty, RFeature segment, ROperation op) {
 		val outerPropertyType = outerPojoProperty.type.itemType
 		val innerProp = if (outputExpressionType instanceof RJavaWithMetaValue && outerPropertyType instanceof JavaPojoInterface) {
-			findPojoProperty(segment, outerPropertyType)
+			getPojoProperty(segment, outerPropertyType)
 		} else {
 			outerPojoProperty
 		}
@@ -525,7 +525,7 @@ class FunctionGenerator {
 	}
 	
 	//The type of the output expression to be set and the pojo property type are not the same when working with meta
-	private def JavaPojoProperty findPojoProperty(RFeature seg, JavaType outputExpressionType) {
+	private def JavaPojoProperty getPojoProperty(RFeature seg, JavaType outputExpressionType) {
 		if (seg instanceof RMetaAttribute && outputExpressionType.itemType instanceof RJavaFieldWithMeta) {
 			(outputExpressionType as JavaPojoInterface).findProperty("meta")
 		} else if (seg instanceof RMetaAttribute && outputExpressionType.itemType instanceof RJavaReferenceWithMeta) {

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/scoping/RosettaScopeProvider.xtend
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/scoping/RosettaScopeProvider.xtend
@@ -147,7 +147,7 @@ class RosettaScopeProvider extends ImportedNamespaceAwareLocalScopeProvider {
 						Operation: {
 							val receiverType = typeProvider.getRTypeOfSymbol(context.assignRoot)
 							val features = receiverType.allFeatures(context, [t| !(t instanceof REnumType)])
-							return Scopes.scopeFor(features)  //TODO: don't get all features (i.e enum atrs)
+							return Scopes.scopeFor(features)
 						}
 						// Case handles the tail of the segment
 						Segment: {
@@ -155,7 +155,7 @@ class RosettaScopeProvider extends ImportedNamespaceAwareLocalScopeProvider {
 							if (prev !== null) {
 								if (prev.feature.isResolved) {
 									val receiverType = typeProvider.getRTypeOfFeature(prev.feature, context)
-									return Scopes.scopeFor(receiverType.allFeatures(context, [t| !(t instanceof REnumType)])) //TODO: don't get all features (i.e enum atrs)
+									return Scopes.scopeFor(receiverType.allFeatures(context, [t| !(t instanceof REnumType)]))
 								}
 							}
 							if (context.eContainer instanceof Operation) {

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/scoping/RosettaScopeProvider.xtend
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/scoping/RosettaScopeProvider.xtend
@@ -146,8 +146,7 @@ class RosettaScopeProvider extends ImportedNamespaceAwareLocalScopeProvider {
 						// Case handles the head of the segment
 						Operation: {
 							val receiverType = typeProvider.getRTypeOfSymbol(context.assignRoot)
-							val features = receiverType.allFeatures(context, [t| !(t instanceof REnumType)])
-							return Scopes.scopeFor(features)
+							return Scopes.scopeFor(receiverType.allFeatures(context, [t| !(t instanceof REnumType)]))
 						}
 						// Case handles the tail of the segment
 						Segment: {


### PR DESCRIPTION
This PR implements the ability to set meta where it is nested in objects using the set/add operators as outlined in the first section of https://github.com/finos/rune-dsl/issues/847