### PR TITLE
Invalid codegen for TypeFormatValidators with typeAlias conditions

### DIFF
--- a/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/condition/TypeAliasConditionTest.java
+++ b/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/condition/TypeAliasConditionTest.java
@@ -266,10 +266,8 @@ public class TypeAliasConditionTest extends AbstractConditionTest {
 		
 		assertResults(
 			results,
-			(v1) -> assertSuccess(v1, "T", "T"),
-			(v2) -> assertSuccess(v2, "Cond1", "T"),
-			(v3) -> assertSuccess(v3, "FooAliasCondA", "T.atr1"),
-			(v4) -> assertFailure(v4, "FooAliasCondB", "T.atr1", "[String] [foo] should not equal [String] [foo]")
+			(v1) -> assertSuccess(v1, "FooAliasCondA", "T.atr1"),
+			(v2) -> assertFailure(v2, "FooAliasCondB", "T.atr1", "[String] [foo] should not equal [String] [foo]")
 		);
 	}
 	
@@ -303,10 +301,8 @@ public class TypeAliasConditionTest extends AbstractConditionTest {
 		
 		assertResults(
 			results,
-			(v1) -> assertSuccess(v1, "T", "T"),
-			(v2) -> assertSuccess(v2, "Cond1", "T"),
-			(v3) -> assertSuccess(v3, "FooAliasCondA", "T.atr1"),
-			(v4) -> assertFailure(v4, "FooAliasCondB", "T.atr1", "[String] [foo] should not equal [String] [foo]")
+			(v1) -> assertSuccess(v1, "FooAliasCondA", "T.atr1"),
+			(v2) -> assertFailure(v2, "FooAliasCondB", "T.atr1", "[String] [foo] should not equal [String] [foo]")
 		);
 	}
 }

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/object/ValidatorsGenerator.xtend
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/generator/java/object/ValidatorsGenerator.xtend
@@ -155,7 +155,7 @@ class ValidatorsGenerator {
 			
 			private «List»<«ValidationResult»<?>> runConditions(«RosettaPath» «pathId», «javaType» «instanceId») {
 				«List»<«ValidationResult»<?>> «resultsId» = new «ArrayList»();
-				«FOR condCheck : attributes.map[checkTypeConditions(javaType, it, aliasHierarchyPerAttribute.get(it), pathId, instanceVar, resultsId, classScope)] SEPARATOR ", "»
+				«FOR condCheck : attributes.map[checkTypeConditions(javaType, it, aliasHierarchyPerAttribute.get(it), pathId, instanceVar, resultsId, classScope)]»
 				«condCheck.asStatementList»
 				«ENDFOR»
 				return «resultsId»;


### PR DESCRIPTION
## Problem Summary

When generating type format validators from a model with `typeAlias` conditions, the output Java contains invalid syntax due to extra commas caused by empty `JavaBlock` elements in `runConditions` method.

## Suspected Cause

The `checkTypeConditions` call in `ValidatorsGenerator.xtend` at line 158 returns empty `JavaBlock` objects for some attributes, which are not filtered out. Also, the comma `SEPARATOR` is creating compilation errors.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
