### PR TITLE
Story-1254: Show error for duplicate attributes in the same type

### DIFF
--- a/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/validation/RosettaValidatorTest.java
+++ b/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/validation/RosettaValidatorTest.java
@@ -1761,7 +1761,7 @@ public class RosettaValidatorTest extends AbstractValidatorTest {
 				type Bar extends Foo:
 					i int (0..1)
 				""");
-        validationTestHelper.assertWarning(model, ATTRIBUTE, null, "Duplicate attribute 'i'. To override the type, cardinality or annotations of this attribute, use the keyword `override`.");
+        validationTestHelper.assertWarning(model, ATTRIBUTE, null, "Attribute 'i' already defined in super type. To override the type, cardinality or annotations of this attribute, use the keyword `override`.");
     }
 
     @Test
@@ -1773,7 +1773,7 @@ public class RosettaValidatorTest extends AbstractValidatorTest {
 				type Bar extends Foo:
 					i int (1..*)
 				""");
-        validationTestHelper.assertWarning(model, ATTRIBUTE, null, "Duplicate attribute 'i'. To override the type, cardinality or annotations of this attribute, use the keyword `override`.");
+        validationTestHelper.assertWarning(model, ATTRIBUTE, null, "Attribute 'i' already defined in super type. To override the type, cardinality or annotations of this attribute, use the keyword `override`.");
     }
 
     @Test
@@ -1785,7 +1785,7 @@ public class RosettaValidatorTest extends AbstractValidatorTest {
 				type Bar extends Foo:
 					i string (1..1)
 				""");
-        validationTestHelper.assertWarning(model, ATTRIBUTE, null, "Duplicate attribute 'i'. To override the type, cardinality or annotations of this attribute, use the keyword `override`.");
+        validationTestHelper.assertWarning(model, ATTRIBUTE, null, "Attribute 'i' already defined in super type. To override the type, cardinality or annotations of this attribute, use the keyword `override`.");
     }
 
     @Test

--- a/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/validation/RosettaValidatorTest.java
+++ b/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/validation/RosettaValidatorTest.java
@@ -1761,7 +1761,7 @@ public class RosettaValidatorTest extends AbstractValidatorTest {
 				type Bar extends Foo:
 					i int (0..1)
 				""");
-        validationTestHelper.assertWarning(model, ATTRIBUTE, null, "Attribute 'i' already defined in super type. To override the type, cardinality or annotations of this attribute, use the keyword `override`.");
+        validationTestHelper.assertWarning(model, ATTRIBUTE, null, "Attribute 'i' already defined in super type. To override the type, cardinality or annotations of this attribute, use the keyword `override`");
     }
 
     @Test
@@ -1773,7 +1773,7 @@ public class RosettaValidatorTest extends AbstractValidatorTest {
 				type Bar extends Foo:
 					i int (1..*)
 				""");
-        validationTestHelper.assertWarning(model, ATTRIBUTE, null, "Attribute 'i' already defined in super type. To override the type, cardinality or annotations of this attribute, use the keyword `override`.");
+        validationTestHelper.assertWarning(model, ATTRIBUTE, null, "Attribute 'i' already defined in super type. To override the type, cardinality or annotations of this attribute, use the keyword `override`");
     }
 
     @Test
@@ -1785,7 +1785,7 @@ public class RosettaValidatorTest extends AbstractValidatorTest {
 				type Bar extends Foo:
 					i string (1..1)
 				""");
-        validationTestHelper.assertWarning(model, ATTRIBUTE, null, "Attribute 'i' already defined in super type. To override the type, cardinality or annotations of this attribute, use the keyword `override`.");
+        validationTestHelper.assertWarning(model, ATTRIBUTE, null, "Attribute 'i' already defined in super type. To override the type, cardinality or annotations of this attribute, use the keyword `override`");
     }
 
     @Test

--- a/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/validation/TypeValidatorTest.java
+++ b/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/validation/TypeValidatorTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(InjectionExtension.class)
 @InjectWith(RosettaTestInjectorProvider.class)
-public class TypeValidatorTest extends AbstractValidatorTest {
+class TypeValidatorTest extends AbstractValidatorTest {
     @Test
     void testTypeNameShouldBeCapitalized() {
         assertIssues("""
@@ -39,7 +39,7 @@ public class TypeValidatorTest extends AbstractValidatorTest {
                             override attr number (1..1)
                         """,
                 """
-                        ERROR (null) 'Attribute overrides should come before any new attributes.' at 9:5, length 27, on Attribute
+                        ERROR (null) 'Attribute overrides should come before any new attributes' at 9:5, length 27, on Attribute
                         """);
     }
 
@@ -54,7 +54,7 @@ public class TypeValidatorTest extends AbstractValidatorTest {
                             override attr int (1..1)
                         """,
                 """
-                        ERROR (null) 'Duplicate attribute override for 'attr'.' at 9:14, length 4, on Attribute
+                        ERROR (null) 'Attribute 'attr' already defined' at 9:14, length 4, on Attribute
                         """);
     }
 
@@ -69,7 +69,19 @@ public class TypeValidatorTest extends AbstractValidatorTest {
                             attr string (1..1)
                         """,
                 """
-                        WARNING (null) 'Duplicate attribute 'attr'. To override the type, cardinality or annotations of this attribute, use the keyword `override`.' at 8:5, length 4, on Attribute
+                        ERROR (null) 'Attribute 'attr' already defined in super type. To override the type, cardinality or annotations of this attribute, use the keyword `override`' at 8:5, length 4, on Attribute
+                        """);
+    }
+
+    @Test
+    void testCannotHaveDuplicateAttributeOnSameType() {
+        assertIssues("""
+                        type Foo:
+                            attr number (0..1)
+                            attr number (0..1)
+                        """,
+                """
+                        ERROR (null) 'Attribute 'attr' already defined' at 6:5, length 4, on Attribute
                         """);
     }
 

--- a/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/validation/TypeValidatorTest.java
+++ b/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/validation/TypeValidatorTest.java
@@ -69,7 +69,7 @@ class TypeValidatorTest extends AbstractValidatorTest {
                             attr string (1..1)
                         """,
                 """
-                        ERROR (null) 'Attribute 'attr' already defined in super type. To override the type, cardinality or annotations of this attribute, use the keyword `override`' at 8:5, length 4, on Attribute
+                        WARNING (null) 'Attribute 'attr' already defined in super type. To override the type, cardinality or annotations of this attribute, use the keyword `override`' at 8:5, length 4, on Attribute
                         """);
     }
 

--- a/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/validation/TypeValidatorTest.java
+++ b/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/validation/TypeValidatorTest.java
@@ -59,7 +59,7 @@ class TypeValidatorTest extends AbstractValidatorTest {
     }
 
     @Test
-    void testOverridingAttributeWithoutKeywordIsDeprecated() {
+    void testCannotHaveDuplicateAttributeToSuperTypeWithoutOverriding() {
         // Note: once support is dropped, this should become a duplicate attribute error.
         assertIssues("""
                         type Foo:
@@ -74,7 +74,7 @@ class TypeValidatorTest extends AbstractValidatorTest {
     }
 
     @Test
-    void testCannotHaveDuplicateAttributeOnSameType() {
+    void testCannotNotHaveDuplicateAttributeOnSameType() {
         assertIssues("""
                         type Foo:
                             attr number (0..1)
@@ -82,6 +82,21 @@ class TypeValidatorTest extends AbstractValidatorTest {
                         """,
                 """
                         ERROR (null) 'Attribute 'attr' already defined' at 6:5, length 4, on Attribute
+                        """);
+    }
+
+    @Test
+    void testDuplicateAttributeErrorWhenAttributeAlreadyOverridden() {
+        assertIssues("""
+                        type Foo:
+                            attr number (0..1)
+
+                        type Bar extends Foo:
+                            override attr number (0..1)
+                            attr string (1..1)
+                        """,
+                """
+                        ERROR (null) 'Attribute 'attr' already defined' at 9:5, length 4, on Attribute
                         """);
     }
 

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/validation/TypeValidator.java
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/validation/TypeValidator.java
@@ -79,10 +79,11 @@ public class TypeValidator extends AbstractDeclarativeRosettaValidator {
 			ecoreUtil.getAllAttributes(data.getSuperType()).forEach(attr -> usedNamesInSuperType.add(attr.getName()));
 		}
 		for (Attribute attr: data.getAttributes()) {
-			if (!attr.isOverride() && usedNamesInSuperType.contains(attr.getName())) {
-				error("Attribute '" + attr.getName() + "' already defined in super type. To override the type, cardinality or annotations of this attribute, use the keyword `override`", attr, ROSETTA_NAMED__NAME);
-			} else if (!usedNamesInType.add(attr.getName())) {
+			if (!usedNamesInType.add(attr.getName())) {
 				error("Attribute '" + attr.getName() + "' already defined", attr, ROSETTA_NAMED__NAME);
+			}
+			else if (!attr.isOverride() && usedNamesInSuperType.contains(attr.getName())) {
+				error("Attribute '" + attr.getName() + "' already defined in super type. To override the type, cardinality or annotations of this attribute, use the keyword `override`", attr, ROSETTA_NAMED__NAME);
 			}
 		}
 	}

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/validation/TypeValidator.java
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/validation/TypeValidator.java
@@ -83,7 +83,8 @@ public class TypeValidator extends AbstractDeclarativeRosettaValidator {
 				error("Attribute '" + attr.getName() + "' already defined", attr, ROSETTA_NAMED__NAME);
 			}
 			else if (!attr.isOverride() && usedNamesInSuperType.contains(attr.getName())) {
-				error("Attribute '" + attr.getName() + "' already defined in super type. To override the type, cardinality or annotations of this attribute, use the keyword `override`", attr, ROSETTA_NAMED__NAME);
+				// TODO: make this an error once `override` keyword is mandatory
+				warning("Attribute '" + attr.getName() + "' already defined in super type. To override the type, cardinality or annotations of this attribute, use the keyword `override`", attr, ROSETTA_NAMED__NAME);
 			}
 		}
 	}


### PR DESCRIPTION
Story-1254: Show error for duplicate attributes in the same type

Changes include:
- Update existing check for unique attribute names to error when there are:
  - duplicate attributes in type
  - duplicate attributes in super type
- Update duplicate attribute error messages

## Type of change

- New feature (non-breaking change which adds functionality)
