### PR TITLE
Set metadata key in a super type 

### DIFF
--- a/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorMetaTest.java
+++ b/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorMetaTest.java
@@ -35,20 +35,25 @@ public class FunctionGeneratorMetaTest {
                 metaType key string
         
                 type Foo:
+                   someFooField string (1..1)
+        
+                type Bar extends Foo:
                   [metadata key]
-                   someField string (1..1)
+                   someBarField string (1..1)
         
                 func MyFunc:
                     inputs:
-                        inField string (1..1)
+                        inBarField string (1..1)
+                        inFooField string (1..1)
                         inKey string (1..1)
         
                     output:
                         result Foo (1..1)
         
                     set result:
-                        Foo {
-                                someField: inField
+                        Bar {
+                                someBarField: inBarField,
+                                someFooField: inFooField
                             } with-meta {
                                   key: inKey
                               }
@@ -60,10 +65,11 @@ public class FunctionGeneratorMetaTest {
 
         var myFunc = functionGeneratorHelper.createFunc(classes, "MyFunc");
 
-        var result = functionGeneratorHelper.invokeFunc(myFunc, RosettaModelObject.class, "someFieldValue", "someKey");
+        var result = functionGeneratorHelper.invokeFunc(myFunc, RosettaModelObject.class, "someBarFieldValue", "someFooFieldValue", "someKey");
 
-        var expected = generatorTestHelper.createInstanceUsingBuilder(classes, DottedPath.splitOnDots("com.rosetta.test.model"), "Foo", Map.of(
-                        "someField", "someFieldValue",
+        var expected = generatorTestHelper.createInstanceUsingBuilder(classes, DottedPath.splitOnDots("com.rosetta.test.model"), "Bar", Map.of(
+                        "someBarField", "someBarFieldValue",
+                        "someFooField", "someFooFieldValue",
                         "meta", MetaFields.builder().setExternalKey("someKey").build()
                 )
         );

--- a/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorMetaTest.java
+++ b/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorMetaTest.java
@@ -30,6 +30,50 @@ public class FunctionGeneratorMetaTest {
     private CodeGeneratorTestHelper generatorTestHelper;
 
     @Test
+    void canSetUsingSettersKeyOnSuperType() {
+        var model = """
+                metaType key string
+        
+                type Foo:
+                   [metadata key]
+                   someFooField string (1..1)
+        
+                type Bar extends Foo:
+                   someBarField string (1..1)
+        
+                func MyFunc:
+                    inputs:
+                        inBarField string (1..1)
+                        inFooField string (1..1)
+                        inKey string (1..1)
+        
+                    output:
+                        result Bar (1..1)
+        
+                    set result -> someBarField: inBarField
+                    set result -> someFooField: inFooField
+                    set result -> key: inKey
+        """;
+
+        var code = generatorTestHelper.generateCode(model);
+
+        var classes = generatorTestHelper.compileToClasses(code);
+
+        var myFunc = functionGeneratorHelper.createFunc(classes, "MyFunc");
+
+        var result = functionGeneratorHelper.invokeFunc(myFunc, RosettaModelObject.class, "someBarFieldValue", "someFooFieldValue", "someKey");
+
+        var expected = generatorTestHelper.createInstanceUsingBuilder(classes, DottedPath.splitOnDots("com.rosetta.test.model"), "Bar", Map.of(
+                        "someBarField", "someBarFieldValue",
+                        "someFooField", "someFooFieldValue",
+                        "meta", MetaFields.builder().setExternalKey("someKey").build()
+                )
+        );
+
+        assertEquals(expected, result);
+    }
+
+    @Test
     void canSetUsingWithMetaKeyOnSuperType() {
         var model = """
                 metaType key string

--- a/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorMetaTest.java
+++ b/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorMetaTest.java
@@ -48,7 +48,7 @@ public class FunctionGeneratorMetaTest {
                         inKey string (1..1)
         
                     output:
-                        result Foo (1..1)
+                        result Bar (1..1)
         
                     set result:
                         Bar {

--- a/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorMetaTest.java
+++ b/rosetta-integration-tests/src/test/java/com/regnosys/rosetta/generator/java/function/FunctionGeneratorMetaTest.java
@@ -35,10 +35,10 @@ public class FunctionGeneratorMetaTest {
                 metaType key string
         
                 type Foo:
+                   [metadata key]
                    someFooField string (1..1)
         
                 type Bar extends Foo:
-                  [metadata key]
                    someBarField string (1..1)
         
                 func MyFunc:

--- a/rosetta-lang/src/main/java/com/regnosys/rosetta/types/RosettaTypeProvider.java
+++ b/rosetta-lang/src/main/java/com/regnosys/rosetta/types/RosettaTypeProvider.java
@@ -112,10 +112,20 @@ public class RosettaTypeProvider extends RosettaExpressionSwitch<RMetaAnnotatedT
         }
         return List.of();
     }
-    
+
     public List<RMetaAttribute> getRMetaAttributesOfType(Data data) {
-    	List<AnnotationRef> annotations = data.getAnnotations();
-    	return getRMetaAttributes(annotations);
+        Set<AnnotationRef> allAnnotations = new HashSet<>();
+        Set<Data> visited = new HashSet<>();
+        Data current = data;
+        while (current != null && visited.add(current)) {
+            allAnnotations.addAll(current.getAnnotations());
+            Data superType = current.getSuperType();
+            if (superType != null && !extensions.isResolved(superType)) {
+                break;
+            }
+            current = superType;
+        }
+        return getRMetaAttributes(new ArrayList<>(allAnnotations));
     }
 
     public List<RMetaAttribute> getRMetaAttributes(List<AnnotationRef> annotations) {


### PR DESCRIPTION
This change allows you to set the metadata key on a type that has the metadata key annotated on its super type. The change only affects the user of setters as the `with-meta` syntax already allowed this.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
