### PR TITLE
Multi cardinality CSV attributes

### DIFF
--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/utils/CsvUtilTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/utils/CsvUtilTest.java
@@ -141,4 +141,98 @@ public class CsvUtilTest {
         var data = model.getType(typeName);
         return rObjectFactory.buildRDataType(data);
     }
+    // ---------------------------------------------------------------------------
+    // Metadata-annotated attributes are not tabular
+    //
+    // A metadata annotation generates a FieldWithMeta* wrapper rather than a scalar, and a CSV cell
+    // has no shape for an object. Measured in rune-common: writing one fails with "CSV generator does
+    // not support Object values", reading one fails with "Cannot construct instance of
+    // FieldWithMetaString ... from String value". Neither direction round-trips, at either
+    // cardinality, so such a type is refused here rather than at runtime.
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void typeWithSchemeMetadataAttributeIsNotTabular() {
+        assertNotTabular("Foo", """
+                type Foo:
+                	withScheme string (1..1)
+                		[metadata scheme]
+                """);
+    }
+
+    @Test
+    void typeWithIdMetadataAttributeIsNotTabular() {
+        assertNotTabular("Foo", """
+                type Foo:
+                	withId string (1..1)
+                		[metadata id]
+                """);
+    }
+
+    @Test
+    void typeWithMultiCardinalityMetadataAttributeIsNotTabular() {
+        // The cardinality relaxation must not let this one through: it is rejected for carrying
+        // metadata, not for being a list.
+        assertNotTabular("Foo", """
+                type Foo:
+                	schemeList string (0..*)
+                		[metadata scheme]
+                """);
+    }
+
+    @Test
+    void typeWithInheritedMetadataAttributeIsNotTabular() {
+        // getAllAttributes() includes inherited attributes, so a supertype's metadata attribute
+        // disqualifies the subtype too.
+        assertNotTabular("Foo", """
+                type Base:
+                	withScheme string (1..1)
+                		[metadata scheme]
+
+                type Foo extends Base:
+                	own string (0..1)
+                """);
+    }
+
+    @Test
+    void typeWhoseMetadataAttributeIsRemovedIsStillNotTabular() {
+        // The plain sibling of the above, to show the rejection is the metadata and nothing else.
+        assertTabular("Foo", """
+                type Base:
+                	plain string (1..1)
+
+                type Foo extends Base:
+                	own string (0..1)
+                """);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Inheritance, pinned because getNonSimpleAttributes walks getAllAttributes()
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void typeWithInheritedMultiCardinalitySimpleAttributeIsTabular() {
+        assertTabular("Foo", """
+                type Base:
+                	stringList string (0..*)
+
+                type Foo extends Base:
+                	own string (0..1)
+                """);
+    }
+
+    @Test
+    void typeWithInheritedComplexAttributeIsNotTabular() {
+        assertNotTabular("Foo", """
+                type Bar:
+
+                type Base:
+                	complexAttr Bar (1..1)
+
+                type Foo extends Base:
+                	own string (0..1)
+                """);
+    }
+
+
 }

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/utils/CsvUtilTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/utils/CsvUtilTest.java
@@ -44,19 +44,83 @@ public class CsvUtilTest {
     }
     
     @Test
-    void typeWithMultiAttributeIsNotTabular() {
-        assertNotTabular("Foo", """
+    void typeWithMultiCardinalitySimpleAttributeIsTabular() {
+        assertTabular("Foo", """
                 type Foo:
                 	stringList string (0..*)
                 """);
     }
-    
+
+    @Test
+    void typeWithMultiCardinalityEnumAttributeIsTabular() {
+        assertTabular("Foo", """
+                type Foo:
+                	barList Bar (0..*)
+
+                enum Bar:
+                    VALUE1
+                    VALUE2
+                """);
+    }
+
+    @Test
+    void typeWithMultiCardinalityTypeAliasOverBasicAttributeIsTabular() {
+        assertTabular("Foo", """
+                type Foo:
+                	quxList Qux (0..*)
+
+                typeAlias Qux:
+                    date
+                """);
+    }
+
+    @Test
+    void typeWithMultiCardinalityDataTypeAttributeIsNotTabular() {
+        assertNotTabular("Foo", """
+                type Foo:
+                	barList Bar (0..*)
+
+                type Bar:
+                """);
+    }
+
+    @Test
+    void typeWithMultiCardinalityChoiceTypeAttributeIsNotTabular() {
+        assertNotTabular("Foo", """
+                type Foo:
+                	fooList Baz (0..*)
+
+                type Bar:
+                    barAttr int (1..1)
+
+                type Qux:
+                    quxAttr int (1..1)
+
+                choice Baz:
+                    Bar
+                    Qux
+                """);
+    }
+
+    @Test
+    void typeWithMultiCardinalityTypeAliasOverDataTypeAttributeIsNotTabular() {
+        assertNotTabular("Foo", """
+                type Foo:
+                	barList Qux (0..*)
+
+                type Bar:
+
+                typeAlias Qux:
+                    Bar
+                """);
+    }
+
     @Test
     void typeWithComplexAttributeIsNotTabular() {
         assertNotTabular("Foo", """
                 type Foo:
                 	complex Bar (1..1)
-                
+
                 type Bar:
                 """);
     }

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/utils/CsvUtilTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/utils/CsvUtilTest.java
@@ -141,15 +141,7 @@ public class CsvUtilTest {
         var data = model.getType(typeName);
         return rObjectFactory.buildRDataType(data);
     }
-    // ---------------------------------------------------------------------------
-    // Metadata-annotated attributes are not tabular
-    //
-    // A metadata annotation generates a FieldWithMeta* wrapper rather than a scalar, and a CSV cell
-    // has no shape for an object. Measured in rune-common: writing one fails with "CSV generator does
-    // not support Object values", reading one fails with "Cannot construct instance of
-    // FieldWithMetaString ... from String value". Neither direction round-trips, at either
-    // cardinality, so such a type is refused here rather than at runtime.
-    // ---------------------------------------------------------------------------
+    // Metadata generates a FieldWithMeta* wrapper, which a CSV cell can't hold in either direction.
 
     @Test
     void typeWithSchemeMetadataAttributeIsNotTabular() {
@@ -171,8 +163,6 @@ public class CsvUtilTest {
 
     @Test
     void typeWithMultiCardinalityMetadataAttributeIsNotTabular() {
-        // The cardinality relaxation must not let this one through: it is rejected for carrying
-        // metadata, not for being a list.
         assertNotTabular("Foo", """
                 type Foo:
                 	schemeList string (0..*)
@@ -182,8 +172,6 @@ public class CsvUtilTest {
 
     @Test
     void typeWithInheritedMetadataAttributeIsNotTabular() {
-        // getAllAttributes() includes inherited attributes, so a supertype's metadata attribute
-        // disqualifies the subtype too.
         assertNotTabular("Foo", """
                 type Base:
                 	withScheme string (1..1)
@@ -195,8 +183,7 @@ public class CsvUtilTest {
     }
 
     @Test
-    void typeWhoseMetadataAttributeIsRemovedIsStillNotTabular() {
-        // The plain sibling of the above, to show the rejection is the metadata and nothing else.
+    void typeWhoseMetadataAttributeIsRemovedIsTabular() {
         assertTabular("Foo", """
                 type Base:
                 	plain string (1..1)
@@ -205,10 +192,6 @@ public class CsvUtilTest {
                 	own string (0..1)
                 """);
     }
-
-    // ---------------------------------------------------------------------------
-    // Inheritance, pinned because getNonSimpleAttributes walks getAllAttributes()
-    // ---------------------------------------------------------------------------
 
     @Test
     void typeWithInheritedMultiCardinalitySimpleAttributeIsTabular() {

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/FunctionValidatorTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/FunctionValidatorTest.java
@@ -330,12 +330,6 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
             WARNING (null) 'Functions annotated with codeImplementation should not have any setter operations as they will be overriden' at 4:6, length 3, on Function
             """);
     }
-    /**
-     * The modeller-facing outcome of refusing a metadata-annotated attribute: it is reported by the
-     * same "must be a tabular type" error that a complex attribute gets, and names the attribute. Such
-     * an attribute generates a FieldWithMeta* wrapper, which no CSV serialiser can write to a cell or
-     * read back from one.
-     */
     @Test
     void csvProjectionOutputWithMetadataAttributeIsNotTabular() {
         assertIssues("""

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/FunctionValidatorTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/FunctionValidatorTest.java
@@ -110,6 +110,164 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
     }
 
     @Test
+    void csvIngestionInputWithMultiCardinalitySimpleAttributeIsTabular() {
+        assertNoIssues("""
+                type Input:
+                   attr string (1..1)
+                   stringList string (0..*)
+
+                func MyFunc:
+                   [ingest CSV]
+                   inputs:
+                       inp Input (1..1)
+                """
+        );
+    }
+
+    @Test
+    void csvProjectionOutputWithMultiCardinalitySimpleAttributeIsTabular() {
+        assertNoIssues("""
+                type Input:
+                   attr string (1..1)
+                   stringList string (0..*)
+
+                func MyFunc:
+                   [projection CSV]
+                   inputs:
+                       inp string (1..1)
+                   output:
+                       result Input (1..1)
+
+                   set result: Input { attr: inp, stringList: empty }
+                """
+        );
+    }
+
+    @Test
+    void csvProjectionOutputMustBeSingleCardinality() {
+    	assertIssues("""
+                type Input:
+                   attr string (1..1)
+
+                func MyFunc:
+                   [projection CSV]
+                   inputs:
+                       inp string (1..1)
+                   output:
+                       result Input (0..*)
+
+                   set result: [ Input { attr: inp } ]
+                """, """
+                ERROR (null) 'The output of a CSV projection function must be single cardinality' at 12:21, length 6, on Attribute
+                """
+    		);
+    }
+
+    @Test
+    void csvLabelledProjectionOutputMustBeTabular() {
+        assertIssues("""
+                type Input:
+                   attr string (1..1)
+                   complexAttr Foo (1..1)
+
+                type Foo:
+
+                func MyFunc:
+                   [projection CSV_LABELLED]
+                   inputs:
+                       inp string (1..1)
+                   output:
+                       result Input (1..1)
+
+                   set result: Input { attr: inp, complexAttr: Foo { } }
+                """, """
+                ERROR (null) 'The output of a CSV projection function must be a tabular type. Type `Input` has non-simple attributes: `complexAttr`' at 15:15, length 5, on Attribute
+                """
+        );
+    }
+
+    @Test
+    void csvLabelledIngestionInputMustBeTabular() {
+        assertIssues("""
+                type Input:
+                   attr string (1..1)
+                   complexAttr Foo (1..1)
+
+                type Foo:
+
+                func MyFunc:
+                   [ingest CSV_LABELLED]
+                   inputs:
+                       inp Input (1..1)
+                """, """
+                ERROR (null) 'The input of a CSV ingest function must be a tabular type. Type `Input` has non-simple attributes: `complexAttr`' at 13:12, length 5, on Attribute
+                """
+        );
+    }
+
+    @Test
+    void csvLabelledProjectionOverFlatTypeIsTabular() {
+        assertNoIssues("""
+                type Input:
+                   attr string (1..1)
+                   enumAttr Bar (1..1)
+                   aliasAttr Qux (1..1)
+
+                enum Bar:
+                    VALUE1
+                    VALUE2
+
+                typeAlias Qux:
+                    string
+
+                func MyFunc:
+                   [projection CSV_LABELLED]
+                   inputs:
+                       inp string (1..1)
+                   output:
+                       result Input (1..1)
+
+                   set result: Input { attr: inp, enumAttr: Bar -> VALUE1, aliasAttr: inp }
+                """
+        );
+    }
+
+    @Test
+    void csvLabelledProjectionOutputWithMultiCardinalitySimpleAttributeIsTabular() {
+        assertNoIssues("""
+                type Input:
+                   attr string (1..1)
+                   stringList string (0..*)
+
+                func MyFunc:
+                   [projection CSV_LABELLED]
+                   inputs:
+                       inp string (1..1)
+                   output:
+                       result Input (1..1)
+
+                   set result: Input { attr: inp, stringList: empty }
+                """
+        );
+    }
+
+    @Test
+    void csvLabelledIngestionInputMustBeSingleCardinality() {
+        assertIssues("""
+                type Input:
+                   attr string (1..1)
+
+                func MyFunc:
+                   [ingest CSV_LABELLED]
+                   inputs:
+                       inp Input (0..*)
+                """, """
+                ERROR (null) 'The input of a CSV ingest function must be single cardinality' at 10:18, length 6, on Attribute
+                """
+        );
+    }
+
+    @Test
     void csvIngestionMustHaveOneInput() {
         assertIssues("""
                 type Input:

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/FunctionValidatorTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/FunctionValidatorTest.java
@@ -39,7 +39,7 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
     @Test
     void csvIngestionInputMustBeTabular() {
     	assertIssues("""
-                type Input:
+                type Thing:
                    attr string (1..1)
                    complexAttr Foo (1..1)
                 
@@ -48,9 +48,9 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
                 func MyFunc:
                    [ingest CSV]
                    inputs:
-                       inp Input (1..1)
+                       inp Thing (1..1)
                 """, """
-                ERROR (null) 'The input of a CSV ingest function must be a tabular type. Type `Input` has non-simple attributes: `complexAttr`' at 13:12, length 5, on Attribute
+                ERROR (null) 'The input of a CSV ingest function must be a tabular type. Type `Thing` has non-simple attributes: `complexAttr`' at 13:12, length 5, on Attribute
                 """
     		);
     }
@@ -58,7 +58,7 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
     @Test
     void csvProjectionOutputMustBeTabular() {
         assertIssues("""
-                type Input:
+                type Thing:
                    attr string (1..1)
                    complexAttr Foo (1..1)
                 
@@ -67,11 +67,11 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
                 func MyFunc:
                    [projection CSV]
                    output:
-                       inp Input (1..1)
+                       inp Thing (1..1)
                 """, """
                 WARNING (null) 'A function should specify an implementation, or they should be annotated with codeImplementation' at 10:6, length 6, on Function
                 ERROR (null) 'Transform functions must have a single input.' at 11:4, length 16, on TransformAnnotation
-                ERROR (null) 'The output of a CSV projection function must be a tabular type. Type `Input` has non-simple attributes: `complexAttr`' at 13:12, length 5, on Attribute
+                ERROR (null) 'The output of a CSV projection function must be a tabular type. Type `Thing` has non-simple attributes: `complexAttr`' at 13:12, length 5, on Attribute
                 """
         );
     }
@@ -79,14 +79,14 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
     @Test
     void csvIngestionMayNotHaveMultipleInputs() {
         assertIssues("""
-                type Input:
+                type Thing:
                    attr string (1..1)
                 
                 func MyFunc:
                    [ingest CSV]
                    inputs:
-                       inp Input (1..1)
-                       inp2 Input (1..1)
+                       inp Thing (1..1)
+                       inp2 Thing (1..1)
                 """, """
                 ERROR (null) 'Transform functions may only have a single input.' at 11:8, length 17, on Attribute
                 """
@@ -96,13 +96,13 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
     @Test
     void csvIngestionMayNotHaveMultiInput() {
         assertIssues("""
-                type Input:
+                type Thing:
                    attr string (1..1)
                 
                 func MyFunc:
                    [ingest CSV]
                    inputs:
-                       inp Input (0..*)
+                       inp Thing (0..*)
                 """, """
                 ERROR (null) 'The input of a CSV ingest function must be single cardinality' at 10:18, length 6, on Attribute
                 """
@@ -112,14 +112,14 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
     @Test
     void csvIngestionInputWithMultiCardinalitySimpleAttributeIsTabular() {
         assertNoIssues("""
-                type Input:
+                type Thing:
                    attr string (1..1)
                    stringList string (0..*)
 
                 func MyFunc:
                    [ingest CSV]
                    inputs:
-                       inp Input (1..1)
+                       inp Thing (1..1)
                 """
         );
     }
@@ -127,7 +127,7 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
     @Test
     void csvProjectionOutputWithMultiCardinalitySimpleAttributeIsTabular() {
         assertNoIssues("""
-                type Input:
+                type Thing:
                    attr string (1..1)
                    stringList string (0..*)
 
@@ -136,9 +136,9 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
                    inputs:
                        inp string (1..1)
                    output:
-                       result Input (1..1)
+                       result Thing (1..1)
 
-                   set result: Input { attr: inp, stringList: empty }
+                   set result: Thing { attr: inp, stringList: empty }
                 """
         );
     }
@@ -146,7 +146,7 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
     @Test
     void csvProjectionOutputMustBeSingleCardinality() {
     	assertIssues("""
-                type Input:
+                type Thing:
                    attr string (1..1)
 
                 func MyFunc:
@@ -154,9 +154,9 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
                    inputs:
                        inp string (1..1)
                    output:
-                       result Input (0..*)
+                       result Thing (0..*)
 
-                   set result: [ Input { attr: inp } ]
+                   set result: [ Thing { attr: inp } ]
                 """, """
                 ERROR (null) 'The output of a CSV projection function must be single cardinality' at 12:21, length 6, on Attribute
                 """
@@ -166,7 +166,7 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
     @Test
     void csvLabelledProjectionOutputMustBeTabular() {
         assertIssues("""
-                type Input:
+                type Thing:
                    attr string (1..1)
                    complexAttr Foo (1..1)
 
@@ -177,11 +177,11 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
                    inputs:
                        inp string (1..1)
                    output:
-                       result Input (1..1)
+                       result Thing (1..1)
 
-                   set result: Input { attr: inp, complexAttr: Foo { } }
+                   set result: Thing { attr: inp, complexAttr: Foo { } }
                 """, """
-                ERROR (null) 'The output of a CSV projection function must be a tabular type. Type `Input` has non-simple attributes: `complexAttr`' at 15:15, length 5, on Attribute
+                ERROR (null) 'The output of a CSV projection function must be a tabular type. Type `Thing` has non-simple attributes: `complexAttr`' at 15:15, length 5, on Attribute
                 """
         );
     }
@@ -189,7 +189,7 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
     @Test
     void csvLabelledIngestionInputMustBeTabular() {
         assertIssues("""
-                type Input:
+                type Thing:
                    attr string (1..1)
                    complexAttr Foo (1..1)
 
@@ -198,9 +198,9 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
                 func MyFunc:
                    [ingest CSV_LABELLED]
                    inputs:
-                       inp Input (1..1)
+                       inp Thing (1..1)
                 """, """
-                ERROR (null) 'The input of a CSV ingest function must be a tabular type. Type `Input` has non-simple attributes: `complexAttr`' at 13:12, length 5, on Attribute
+                ERROR (null) 'The input of a CSV ingest function must be a tabular type. Type `Thing` has non-simple attributes: `complexAttr`' at 13:12, length 5, on Attribute
                 """
         );
     }
@@ -208,7 +208,7 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
     @Test
     void csvLabelledProjectionOverFlatTypeIsTabular() {
         assertNoIssues("""
-                type Input:
+                type Thing:
                    attr string (1..1)
                    enumAttr Bar (1..1)
                    aliasAttr Qux (1..1)
@@ -225,9 +225,9 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
                    inputs:
                        inp string (1..1)
                    output:
-                       result Input (1..1)
+                       result Thing (1..1)
 
-                   set result: Input { attr: inp, enumAttr: Bar -> VALUE1, aliasAttr: inp }
+                   set result: Thing { attr: inp, enumAttr: Bar -> VALUE1, aliasAttr: inp }
                 """
         );
     }
@@ -235,7 +235,7 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
     @Test
     void csvLabelledProjectionOutputWithMultiCardinalitySimpleAttributeIsTabular() {
         assertNoIssues("""
-                type Input:
+                type Thing:
                    attr string (1..1)
                    stringList string (0..*)
 
@@ -244,9 +244,9 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
                    inputs:
                        inp string (1..1)
                    output:
-                       result Input (1..1)
+                       result Thing (1..1)
 
-                   set result: Input { attr: inp, stringList: empty }
+                   set result: Thing { attr: inp, stringList: empty }
                 """
         );
     }
@@ -254,13 +254,13 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
     @Test
     void csvLabelledIngestionInputMustBeSingleCardinality() {
         assertIssues("""
-                type Input:
+                type Thing:
                    attr string (1..1)
 
                 func MyFunc:
                    [ingest CSV_LABELLED]
                    inputs:
-                       inp Input (0..*)
+                       inp Thing (0..*)
                 """, """
                 ERROR (null) 'The input of a CSV ingest function must be single cardinality' at 10:18, length 6, on Attribute
                 """
@@ -270,7 +270,7 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
     @Test
     void csvIngestionMustHaveOneInput() {
         assertIssues("""
-                type Input:
+                type Thing:
                    attr string (1..1)
                 
                 func MyFunc:

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/FunctionValidatorTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/FunctionValidatorTest.java
@@ -330,4 +330,32 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
             WARNING (null) 'Functions annotated with codeImplementation should not have any setter operations as they will be overriden' at 4:6, length 3, on Function
             """);
     }
+    /**
+     * The modeller-facing outcome of refusing a metadata-annotated attribute: it is reported by the
+     * same "must be a tabular type" error that a complex attribute gets, and names the attribute. Such
+     * an attribute generates a FieldWithMeta* wrapper, which no CSV serialiser can write to a cell or
+     * read back from one.
+     */
+    @Test
+    void csvProjectionOutputWithMetadataAttributeIsNotTabular() {
+        assertIssues("""
+                type Thing:
+                   attr string (1..1)
+                   withScheme string (1..1)
+                      [metadata scheme]
+
+                func MyFunc:
+                   [projection CSV]
+                   inputs:
+                       inp string (1..1)
+                   output:
+                       result Thing (1..1)
+
+                   set result -> attr: inp
+                """, """
+                ERROR (null) 'The output of a CSV projection function must be a tabular type. Type `Thing` has non-simple attributes: `withScheme`' at 14:15, length 5, on Attribute
+                """
+        );
+    }
+
 }

--- a/rune-lang/src/main/java/com/regnosys/rosetta/utils/CsvUtil.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/utils/CsvUtil.java
@@ -22,7 +22,22 @@ public class CsvUtil {
     }
     
     private boolean isSimpleAttribute(RAttribute attr) {
-        RType baseType = typeSystem.stripFromTypeAliases(attr.getRMetaAnnotatedType().getRType());
+        RMetaAnnotatedType annotatedType = attr.getRMetaAnnotatedType();
+        if (annotatedType.hasAttributeMeta()) {
+            // A metadata-annotated attribute is not a scalar. `[metadata scheme]` or `[metadata id]`
+            // on a string generates a FieldWithMetaString wrapper, and a CSV cell has no shape for an
+            // object: measured in rune-common, writing one fails with "CSV generator does not support
+            // Object values for properties (nested Objects)" and reading one fails with "Cannot
+            // construct instance of FieldWithMetaString ... from String value". It cannot round-trip in
+            // either direction, so treating it as tabular blesses a type no CSV serialiser can handle.
+            //
+            // hasAttributeMeta() excludes `key`, the one metadata that belongs to a type rather than an
+            // attribute — the grammar already refuses `[metadata key]` on an attribute ("annotation only
+            // allowed on a type"). A `key` reaching an attribute's meta therefore came from the type it
+            // points at, which is an RDataType and so is rejected below regardless.
+            return false;
+        }
+        RType baseType = typeSystem.stripFromTypeAliases(annotatedType.getRType());
         return !(baseType instanceof RDataType) && !(baseType instanceof RChoiceType);
     }
 }

--- a/rune-lang/src/main/java/com/regnosys/rosetta/utils/CsvUtil.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/utils/CsvUtil.java
@@ -22,9 +22,6 @@ public class CsvUtil {
     }
     
     private boolean isSimpleAttribute(RAttribute attr) {
-        if (attr.isMulti()) {
-            return false;
-        }
         RType baseType = typeSystem.stripFromTypeAliases(attr.getRMetaAnnotatedType().getRType());
         return !(baseType instanceof RDataType) && !(baseType instanceof RChoiceType);
     }

--- a/rune-lang/src/main/java/com/regnosys/rosetta/utils/CsvUtil.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/utils/CsvUtil.java
@@ -24,17 +24,8 @@ public class CsvUtil {
     private boolean isSimpleAttribute(RAttribute attr) {
         RMetaAnnotatedType annotatedType = attr.getRMetaAnnotatedType();
         if (annotatedType.hasAttributeMeta()) {
-            // A metadata-annotated attribute is not a scalar. `[metadata scheme]` or `[metadata id]`
-            // on a string generates a FieldWithMetaString wrapper, and a CSV cell has no shape for an
-            // object: measured in rune-common, writing one fails with "CSV generator does not support
-            // Object values for properties (nested Objects)" and reading one fails with "Cannot
-            // construct instance of FieldWithMetaString ... from String value". It cannot round-trip in
-            // either direction, so treating it as tabular blesses a type no CSV serialiser can handle.
-            //
-            // hasAttributeMeta() excludes `key`, the one metadata that belongs to a type rather than an
-            // attribute — the grammar already refuses `[metadata key]` on an attribute ("annotation only
-            // allowed on a type"). A `key` reaching an attribute's meta therefore came from the type it
-            // points at, which is an RDataType and so is rejected below regardless.
+            // e.g. [metadata scheme] generates a FieldWithMeta* wrapper, which a CSV cell can't
+            // represent in either direction.
             return false;
         }
         RType baseType = typeSystem.stripFromTypeAliases(annotatedType.getRType());

--- a/rune-lang/src/main/java/com/regnosys/rosetta/validation/FunctionValidator.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/validation/FunctionValidator.java
@@ -75,7 +75,8 @@ public class FunctionValidator extends AbstractDeclarativeRosettaValidator {
     private boolean hasCsvTransformAnnotation(Function function, TransformKind kind) {
         return transformAnnotationHelper.getTransformAnnotation(function)
                 .filter(a -> a.getKind() == kind)
-                .map(a -> transformAnnotationHelper.hasFormat(a, SerializationFormat.CSV))
+                .map(a -> transformAnnotationHelper.hasFormat(a, SerializationFormat.CSV)
+                        || transformAnnotationHelper.hasFormat(a, SerializationFormat.CSV_LABELLED))
                 .orElse(false);
     }
     


### PR DESCRIPTION
## What

Relaxes the DSL's CSV tabular-type rule so a type used with `[ingest CSV]` / `[projection CSV]` may carry a multi-cardinality *simple* attribute — a list of a basic type, enum, or alias over one (e.g. `string (0..*)`) — instead of rejecting every multi-cardinality attribute outright. Data types and choice types are still rejected, at any cardinality. This lets a type model a CSV cell that holds a delimited list (`"EUR;USD;GBP"`), which the rule previously made unrepresentable.

Two smaller changes ride along:

1. **`CSV_LABELLED` is now tabular-checked too.** `FunctionValidator.hasCsvTransformAnnotation` previously matched only `SerializationFormat.CSV`, so a `[ingest CSV_LABELLED]` / `[projection CSV_LABELLED]` function was never checked for tabularity at all — a data-type attribute passed silently. It now matches `CSV_LABELLED` as well, as an `error`, with the same message `CSV` gets. This is a behaviour change for labelled transforms: they are gated from this release where they were not gated before.
2. **A metadata-annotated attribute is not treated as simple.** `withScheme string (1..1) [metadata scheme]` was previously accepted as tabular because the check only looked at the stripped base type. A metadata annotation generates a `FieldWithMeta*` wrapper, and neither writing nor reading a CSV cell for it round-trips — measured directly: write throws `CsvWriteException: CSV generator does not support Object values for properties (nested Objects)`, read throws `MismatchedInputException: Cannot construct instance of FieldWithMetaString ... from String value`. Such an attribute is now rejected by the same "must be a tabular type" error a complex attribute gets. `[metadata key]` is excluded from the check deliberately — the grammar already refuses it on an attribute, so it can only reach an attribute's meta via the type it points at, which is an `RDataType` and is rejected regardless.

## What deliberately did not change

`FunctionValidator.checkAttributeIsTabular`'s separate `attr.isMulti()` guard, which rejects a **function's own** input/output attribute being multi-cardinality (e.g. `[ingest CSV]` on a function whose input is `Foo (0..*)`), is untouched. That guard is about a list of documents, not a list-valued column, and single-column-list serialisation doesn't address it — a CSV ingest still reads one row into one object.

## Why now rather than deferring `CSV_LABELLED` to its retirement

`MIFIRUnavistaCSVDocument` has several attributes commented as needing multi-cardinality (`// must be multi-cardinality. requires projection support upgrades.`), with the projection hand-rolling a delimited join (`... then join ";"`) — exactly the shape this change is meant to let the DSL express. Under the old gap, flipping one of those to `(0..*)` while working on a `CSV_LABELLED` transform got no validation feedback of any kind. Gating `CSV_LABELLED` now moves that feedback earlier rather than leaving it to whenever `CSV_LABELLED` is folded into `CSV`.

## Tests

- `CsvUtilTest`: 15 tests (was 8), covering multi-cardinality basic/enum/alias attributes as tabular, multi-cardinality data-type and choice-type attributes as not tabular, an alias resolving to a data type as not tabular, metadata-annotated attributes (including multi-cardinality) as not tabular, and inherited attributes of each of these shapes via `getAllAttributes()`.
- `FunctionValidatorTest`: 20 tests (was 19), covering both formats × both transform kinds for the relaxation, the surviving function-level cardinality guard on both formats, and the `CSV_LABELLED` tabular gating (including the case where relaxation and labelling compose).
- Locally re-run on this branch: `CsvUtilTest` 15/15 passing, `FunctionValidatorTest` 20/20 passing.
- Full `mvn clean install` across rune-dsl was green when both changes were completed, including `rune-integration-tests` (1505 tests, 0 failures, 0 errors, 21 skipped).

