### PR TITLE
Guard against an unresolved enumeration in `to-enum`

### DIFF
--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/types/RosettaTypeProviderTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/types/RosettaTypeProviderTest.java
@@ -51,6 +51,25 @@ public class RosettaTypeProviderTest {
 	}
 	
 	@Test
+	void testToEnumWithUnresolvedEnumerationHasNoType() {
+		RosettaTestModel model = modelService.toTestModel("""
+				namespace test
+
+				type Foo:
+					a string (1..1)
+				""", false);
+		RosettaExpression expr = model.parseExpression("foo -> a to-enum MissingEnum", "foo Foo (1..1)");
+
+		// An unresolved enumeration is a proxy with no containing model. Building an REnumType from it
+		// produces a type whose name cannot be computed, so anything that reports on this expression -
+		// a validator describing the type in a message, for instance - fails with an NPE instead of
+		// letting the user see the linking error.
+		RMetaAnnotatedType actualType = typeProvider.getRMetaAnnotatedType(expr);
+		Assertions.assertEquals(builtins.NOTHING_WITH_ANY_META, actualType);
+		Assertions.assertDoesNotThrow(() -> actualType.getRType().getName());
+	}
+
+	@Test
 	void testRecursiveRuleTypeInference() {
 		RosettaTestModel model = modelService.toTestModel("""
 				namespace test

--- a/rune-lang/src/main/java/com/regnosys/rosetta/types/RosettaTypeProvider.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/types/RosettaTypeProvider.java
@@ -615,6 +615,12 @@ public class RosettaTypeProvider extends RosettaExpressionSwitch<RMetaAnnotatedT
 
     @Override
     protected RMetaAnnotatedType caseToEnumOperation(ToEnumOperation expr, Map<RosettaSymbol, RMetaAnnotatedType> cycleTracker) {
+        // An unresolved enumeration is a proxy, which has no containing model: building an REnumType
+        // from it yields a type whose name cannot be computed, and any validator that reports on this
+        // expression then fails with an NPE instead of the linking error the user needs to see.
+        if (!extensions.isResolved(expr.getEnumeration())) {
+            return builtins.NOTHING_WITH_ANY_META;
+        }
         return RMetaAnnotatedType.withNoMeta(rObjectFactory.buildREnumType(expr.getEnumeration()));
     }
 


### PR DESCRIPTION
## What

`RosettaTypeProvider.caseToEnumOperation` built an `REnumType` straight from `expr.getEnumeration()` without checking that the reference resolved. Every other cross-reference in that class is guarded with `extensions.isResolved(...)` and falls back to `NOTHING_WITH_ANY_META`; this one was not.

## Why

An unresolved enumeration is an EMF proxy, so it has no containing model. The resulting `REnumType` cannot compute its symbol id, and `RType.getName()` throws:

```
java.lang.NullPointerException: Cannot invoke "com.regnosys.rosetta.rosetta.RosettaModel.getName()" because "namespace" is null
	at com.regnosys.rosetta.utils.ModelIdProvider.toDottedPath(ModelIdProvider.java:13)
	at com.regnosys.rosetta.utils.ModelIdProvider.getSymbolId(ModelIdProvider.java:17)
	at com.regnosys.rosetta.types.REnumType.getSymbolId(REnumType.java:51)
	at com.rosetta.model.lib.ModelSymbol.getName(ModelSymbol.java:29)
	at com.regnosys.rosetta.validation.expression.AbstractExpressionValidator.relevantTypeDescription(AbstractExpressionValidator.java:38)
	at com.regnosys.rosetta.validation.expression.AbstractExpressionValidator.notComparableMessage(AbstractExpressionValidator.java:93)
	at com.regnosys.rosetta.validation.expression.AbstractExpressionValidator.comparableTypeCheck(AbstractExpressionValidator.java:103)
	at com.regnosys.rosetta.validation.expression.ExpressionValidator.checkEqualityOperation(ExpressionValidator.java:212)
	...
```

Nothing calls `getName()` while the type is merely being inferred, so the failure surfaces later and somewhere else — in a validator that reports on the expression and describes its type in the message. `to-enum` against an unresolved enumeration, compared to another type, reaches it through `checkEqualityOperation` → `notComparableMessage` → `relevantTypeDescription`.

Xtext catches the exception from the check method and logs it, so the user never sees a crash — they see the check silently not happen. The linking error for the unresolved reference is still reported, but the type error is not, and the BSP logs an unexplained NPE stacktrace for what is really an ordinary unresolved reference while a model is mid-edit or a dependency has failed to load. This is the same shape as the guards added in #1336.

This was found from a BSP stacktrace reported on a deployed environment, reproduced locally with the trace above.

## Test

`RosettaTypeProviderTest.testToEnumWithUnresolvedEnumerationHasNoType` asserts the inferred type is `NOTHING_WITH_ANY_META` and that naming it does not throw. It fails on `main`:

```
expected: <nothing> but was: <com.regnosys.rosetta.types.RMetaAnnotatedType@573aeab2>
```

and passes with the guard. Full `mvn install` is green (1503 tests in `rune-integration-tests`, checkstyle included).

## Note on scope

The underlying sharp edge is broader: `ModelIdProvider.toDottedPath` dereferences the containing model unconditionally, so any `RType` built from a proxy has the same latent NPE. I kept this change to the one path with a confirmed reproduction rather than hardening `ModelIdProvider` globally, since a blanket fallback there would silently mint bogus symbol ids. Happy to widen it if maintainers prefer.

---

Prepared by *dolphin*, a [SimonAgent](https://github.com/SimonCockx/simon-agent) agent, from [this Slack thread](https://regnosys.slack.com/archives/CE9CH65PS/p1786530997677269?thread_ts=1786530997.677269&cid=CE9CH65PS).