### PR TITLE
[9.x.x] Deprecate CSV_LABELLED in favour of CSV with a LABEL header style

### DIFF
--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/FunctionValidatorTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/FunctionValidatorTest.java
@@ -181,6 +181,7 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
 
                    set result: Thing { attr: inp, complexAttr: Foo { } }
                 """, """
+                WARNING (null) 'CSV_LABELLED is deprecated. Use CSV instead, with "headerStyle": "LABEL" in the CSV serialization configuration. The CSV format honours the whole configuration and resolves the label provider by the same rules.' at 11:16, length 12, on TransformAnnotation
                 ERROR (null) 'The output of a CSV projection function must be a tabular type. Type `Thing` has non-simple attributes: `complexAttr`' at 15:15, length 5, on Attribute
                 """
         );
@@ -200,6 +201,7 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
                    inputs:
                        inp Thing (1..1)
                 """, """
+                WARNING (null) 'CSV_LABELLED is deprecated. Use CSV instead, with "headerStyle": "LABEL" in the CSV serialization configuration. The CSV format honours the whole configuration and resolves the label provider by the same rules.' at 11:12, length 12, on TransformAnnotation
                 ERROR (null) 'The input of a CSV ingest function must be a tabular type. Type `Thing` has non-simple attributes: `complexAttr`' at 13:12, length 5, on Attribute
                 """
         );
@@ -207,7 +209,8 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
 
     @Test
     void csvLabelledProjectionOverFlatTypeIsTabular() {
-        assertNoIssues("""
+        // The deprecation warning is the only issue: the tabular rule accepts this output.
+        assertIssues("""
                 type Thing:
                    attr string (1..1)
                    enumAttr Bar (1..1)
@@ -228,13 +231,16 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
                        result Thing (1..1)
 
                    set result: Thing { attr: inp, enumAttr: Bar -> VALUE1, aliasAttr: inp }
+                """, """
+                WARNING (null) 'CSV_LABELLED is deprecated. Use CSV instead, with "headerStyle": "LABEL" in the CSV serialization configuration. The CSV format honours the whole configuration and resolves the label provider by the same rules.' at 17:16, length 12, on TransformAnnotation
                 """
         );
     }
 
     @Test
     void csvLabelledProjectionOutputWithMultiCardinalitySimpleAttributeIsTabular() {
-        assertNoIssues("""
+        // The deprecation warning is the only issue: the tabular rule accepts a multi-cardinality simple attribute.
+        assertIssues("""
                 type Thing:
                    attr string (1..1)
                    stringList string (0..*)
@@ -247,6 +253,8 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
                        result Thing (1..1)
 
                    set result: Thing { attr: inp, stringList: empty }
+                """, """
+                WARNING (null) 'CSV_LABELLED is deprecated. Use CSV instead, with "headerStyle": "LABEL" in the CSV serialization configuration. The CSV format honours the whole configuration and resolves the label provider by the same rules.' at 9:16, length 12, on TransformAnnotation
                 """
         );
     }
@@ -262,6 +270,7 @@ public class FunctionValidatorTest extends AbstractValidatorTest {
                    inputs:
                        inp Thing (0..*)
                 """, """
+                WARNING (null) 'CSV_LABELLED is deprecated. Use CSV instead, with "headerStyle": "LABEL" in the CSV serialization configuration. The CSV format honours the whole configuration and resolves the label provider by the same rules.' at 8:12, length 12, on TransformAnnotation
                 ERROR (null) 'The input of a CSV ingest function must be single cardinality' at 10:18, length 6, on Attribute
                 """
         );

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/SchemaValidationTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/SchemaValidationTest.java
@@ -95,6 +95,75 @@ public class SchemaValidationTest extends AbstractValidatorTest {
 	}
 
 	@Test
+	void testCsvLabelledSchemaFormatWarns() {
+		assertIssues("""
+				namespace test
+				version "1"
+
+				schema labelledCsvSchema CSV_LABELLED
+				""", """
+				WARNING (null) 'CSV_LABELLED is deprecated. Use CSV instead, with "headerStyle": "LABEL" in the CSV serialization configuration. The CSV format honours the whole configuration and resolves the label provider by the same rules.' at 4:26, length 12, on Schema
+				""");
+	}
+
+	@Test
+	void testCsvLabelledTransformFormatWarns() {
+		assertIssues("""
+				namespace test
+				version "1"
+
+				type Thing:
+					attr string (1..1)
+
+				func MyFunc:
+					[projection CSV_LABELLED]
+					inputs:
+						inp string (1..1)
+					output:
+						result Thing (1..1)
+
+					set result: Thing { attr: inp }
+				""", """
+				WARNING (null) 'CSV_LABELLED is deprecated. Use CSV instead, with "headerStyle": "LABEL" in the CSV serialization configuration. The CSV format honours the whole configuration and resolves the label provider by the same rules.' at 8:14, length 12, on TransformAnnotation
+				""");
+	}
+
+	@Test
+	void testAFunctionUsingACsvLabelledSchemaWarnsOnlyAtTheSchema() {
+		// The schema declaration is the one place the format is written, so it carries the single warning.
+		assertIssues("""
+				namespace test
+				version "1"
+
+				schema labelledCsvSchema CSV_LABELLED
+
+				type Thing:
+					attr string (1..1)
+
+				func MyFunc:
+					[projection labelledCsvSchema]
+					inputs:
+						inp string (1..1)
+					output:
+						result Thing (1..1)
+
+					set result: Thing { attr: inp }
+				""", """
+				WARNING (null) 'CSV_LABELLED is deprecated. Use CSV instead, with "headerStyle": "LABEL" in the CSV serialization configuration. The CSV format honours the whole configuration and resolves the label provider by the same rules.' at 4:26, length 12, on Schema
+				""");
+	}
+
+	@Test
+	void testCsvSchemaFormatDoesNotWarn() {
+		assertNoIssues("""
+				namespace test
+				version "1"
+
+				schema plainCsvSchema CSV
+				""");
+	}
+
+	@Test
 	void testExternalConfigOnNonSchemaIsAnError() {
 		assertIssues("""
 				namespace test

--- a/rune-lang/src/main/java/com/regnosys/rosetta/validation/SchemaValidator.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/validation/SchemaValidator.java
@@ -6,16 +6,25 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.validation.Check;
 
 import com.regnosys.rosetta.config.RuneSchemaConfiguration;
+import com.regnosys.rosetta.rosetta.RosettaEnumValue;
 import com.regnosys.rosetta.rosetta.RosettaPackage;
 import com.regnosys.rosetta.rosetta.Schema;
+import com.regnosys.rosetta.rosetta.SchemaOrFormat;
 import com.regnosys.rosetta.rosetta.simple.AnnotationRef;
 import com.regnosys.rosetta.rosetta.simple.SimplePackage;
+import com.regnosys.rosetta.rosetta.simple.TransformAnnotation;
 import com.regnosys.rosetta.utils.RuneConfigurationHolder;
 import com.regnosys.rosetta.utils.TransformAnnotationHelper;
+import com.rosetta.model.lib.transform.SerializationFormat;
 
 import jakarta.inject.Inject;
 
 public class SchemaValidator extends AbstractDeclarativeRosettaValidator {
+
+    private static final String CSV_LABELLED_DEPRECATED =
+            "CSV_LABELLED is deprecated. Use CSV instead, with \"headerStyle\": \"LABEL\" in the CSV serialization "
+            + "configuration. The CSV format honours the whole configuration and resolves the label provider by the "
+            + "same rules.";
 
     @Inject
     private RuneConfigurationHolder config;
@@ -55,5 +64,33 @@ public class SchemaValidator extends AbstractDeclarativeRosettaValidator {
                             + "', but the schema is not marked [externalConfig], so it will be ignored",
                     schema, RosettaPackage.Literals.ROSETTA_NAMED__NAME);
         }
+    }
+
+    /**
+     * The two places {@code CSV_LABELLED} can be written are a transform annotation's format and a
+     * {@code schema}'s format. Each is matched on the reference itself rather than on the resolved format, so a
+     * function using a {@code CSV_LABELLED} schema is flagged at the schema alone and not twice over.
+     */
+    @Check
+    public void checkCsvLabelledTransformFormatIsDeprecated(TransformAnnotation annotation) {
+        if (isCsvLabelled(annotation.getRef())) {
+            warning(CSV_LABELLED_DEPRECATED, annotation, SimplePackage.Literals.TRANSFORM_ANNOTATION__REF);
+        }
+    }
+
+    @Check
+    public void checkCsvLabelledSchemaFormatIsDeprecated(Schema schema) {
+        if (isCsvLabelled(schema.getFormat())) {
+            warning(CSV_LABELLED_DEPRECATED, schema, RosettaPackage.Literals.SCHEMA__FORMAT);
+        }
+    }
+
+    /**
+     * Both format references are scoped to the built-in {@code SerializationFormat} enum, so a resolved enum
+     * value named {@code CSV_LABELLED} can only be that format.
+     */
+    private boolean isCsvLabelled(SchemaOrFormat formatRef) {
+        return formatRef instanceof RosettaEnumValue format
+                && SerializationFormat.CSV_LABELLED.name().equals(format.getName());
     }
 }

--- a/rune-runtime/src/main/java/com/rosetta/model/lib/transform/SerializationFormat.java
+++ b/rune-runtime/src/main/java/com/rosetta/model/lib/transform/SerializationFormat.java
@@ -18,6 +18,14 @@ public enum SerializationFormat {
     XML,
     /** Comma-separated values. Only valid for tabular types, i.e. types whose attributes are all single-cardinality basic types. */
     CSV,
-    /** Comma-separated values with a header row of human-readable labels. */
+    /**
+     * Comma-separated values with a header row of human-readable labels.
+     *
+     * @deprecated Use {@link #CSV} with {@code "headerStyle": "LABEL"} in the CSV serialization configuration.
+     *             This format reads no configuration at all, so any configuration declared alongside it is
+     *             ignored; {@code CSV} honours the whole configuration and resolves the label provider by the
+     *             same rules.
+     */
+    @Deprecated
     CSV_LABELLED
 }

--- a/rune-runtime/src/main/resources/model/basictypes.rosetta
+++ b/rune-runtime/src/main/resources/model/basictypes.rosetta
@@ -64,5 +64,5 @@ enum SerializationFormat: <"The wire format used to (de)serialize the input or o
 	RUNE_JSON <"JSON, following the Rune-specific JSON standard.">
 	XML <"XML, typically configured by an associated XML configuration file that maps the schema onto the Rune type.">
 	CSV <"Comma-separated values. Only valid for tabular types, i.e. types whose attributes are all single-cardinality basic types.">
-	CSV_LABELLED <"Comma-separated values with a header row of human-readable labels.">
+	CSV_LABELLED <"Deprecated: use CSV with a headerStyle of LABEL in the CSV serialization configuration. Comma-separated values with a header row of human-readable labels. Reads no serialization configuration, so any configuration declared alongside it is ignored.">
 

--- a/website/docs/modelling-components/schema.mdx
+++ b/website/docs/modelling-components/schema.mdx
@@ -26,7 +26,7 @@ The format refers to a value of the built-in `SerializationFormat` enumeration:
 | `RUNE_JSON` | JSON, following the Rune-specific JSON standard. |
 | `XML` | XML, typically configured by an associated XML configuration file that maps the schema onto the Rune type. |
 | `CSV` | Comma-separated values. Only valid for tabular types, i.e. types whose attributes are all single-cardinality basic types. |
-| `CSV_LABELLED` | Comma-separated values with a header row of human-readable labels. |
+| `CSV_LABELLED` | **Deprecated.** Comma-separated values with a header row of human-readable labels. Use `CSV` with a `headerStyle` of `LABEL` in the CSV serialization configuration instead: `CSV_LABELLED` reads no serialization configuration, so any configuration declared alongside it is ignored, whereas `CSV` honours the whole configuration and resolves the label provider by the same rules. Using it reports a warning. |
 
 ## 2. Referencing a schema from a transform function
 


### PR DESCRIPTION
Backport of #1367 to `9.x.x`.

Deprecates the `CSV_LABELLED` serialization format now that `CSV` can do the same job: a validation warning names the replacement wherever the format is used, and the Java `SerializationFormat.CSV_LABELLED` constant is marked `@Deprecated`. The format still works and is not removed —  removal is a later breaking change in the next major version.

The replacement is `CSV` with `"headerStyle": "LABEL"` in the CSV serialization configuration, which landed in rune-common with finos/rune-common#704. That is a strictly better position than `CSV_LABELLED`, which reads no serialization configuration at all: any config declared alongside it is silently ignored, whereas `CSV` honours the whole configuration and resolves the label provider by the same rules. So the gap between the two formats has widened rather than closed, which is what makes the warning worth having now.

The warning appears at each of the two places the format can be written — a transform annotation's format (`[ingest CSV_LABELLED]`) and a `schema`'s format (`schema mySchema CSV_LABELLED`). Both are matched on the reference itself rather than on the resolved format, so a function using a `CSV_LABELLED` schema is flagged once, at the schema declaration, rather than at both the function and the schema. Matching by name is safe here because `RosettaScopeProvider` scopes both references to the built-in `SerializationFormat` enum, so a user-defined enum value of the same name cannot reach either position.

The wording matches what rune-common already logs when it drops a config path on a `CSV_LABELLED` transform (`ClasspathTransformMapperFactory`), so anyone hitting both gets one instruction rather than two.

Deliberately not done two ways it could have been:

1. **No `[deprecated]` annotation on the enum value in `basictypes.rosetta`.** That annotation already works on an enum value, but the shared reporting in `AbstractDeclarativeRosettaValidator.checkDeprecatedAnnotation` hard-codes `info` severity and a `"<name> is deprecated"` message with no way to name a replacement. Since both `TransformAnnotation.ref` and `Schema.format` are cross-references to an `Annotated` target, adding it would also put a second diagnostic on the same token. The docstring carries the migration instead, so editor hover still shows it.
2. **The tabular rule still applies to `CSV_LABELLED`.** `FunctionValidator.hasCsvTransformAnnotation` is untouched. Deprecating the format is not a reason to stop validating models that still use it.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

A model using `CSV_LABELLED` gains a warning where it previously had none, so a build that treats DSL warnings as errors would newly fail. No error, no generator change, and no behaviour change at runtime.

## Tests

Cherry-picked cleanly onto `9.x.x` with no conflicts. Re-ran on `9.x.x` after backporting:

- `SchemaValidationTest`: 11/11 passing (matches the original PR's count — new cases cover the warning on a schema's format, the warning on a transform annotation's format, a function using a `CSV_LABELLED` schema warning only once and at the schema, and `CSV` not warning).
- `FunctionValidatorTest`: 19/19 passing, with the expected warning added to the models that use `CSV_LABELLED` (9.x.x has a different baseline test count than main due to prior branch divergence; all pass here).
- Documented the deprecation in `website/docs/modelling-components/schema.mdx`, the only place the docs list the format.

## Coverage of the production files

Coverage of the two production files was checked by mutation in the original PR (#1367) and reconfirmed unchanged on `9.x.x`, since the cherry-pick applied with no conflicts to either file:

- `SchemaValidator.java` — each new check is independently covered. Disabling `checkCsvLabelledTransformFormatIsDeprecated` fails 6 tests (5 in `FunctionValidatorTest`, 1 in `SchemaValidationTest`); disabling `checkCsvLabelledSchemaFormatIsDeprecated` fails 2 in `SchemaValidationTest`.
- `SerializationFormat.java` — **no test, deliberately**, same as the original PR. The only change is a `@Deprecated` marker and its javadoc on an existing constant. The enum value keeps its name and ordinal, nothing reads the annotation at runtime, and its effect is a javac warning in downstream builds. A test could only assert the annotation is present, which restates the source rather than exercising behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
