### PR TITLE
[9.x.x] Fix highlighting for a reporting/eligibility rule's trailing 'as' label

### DIFF
--- a/rune-ide/rosetta.tmLanguage.yaml
+++ b/rune-ide/rosetta.tmLanguage.yaml
@@ -1255,10 +1255,14 @@ repository:
           patterns:
           - include: '#comment'
         - name: meta.as-operation.rosetta
+          match: '{{wordStart}}as{{wordEnd}}(?!-)(?=\s*[''"])'
+          captures:
+            0: { name: keyword.operator.word.rosetta }
+        - name: meta.as-operation.rosetta
           begin: '{{wordStart}}as{{wordEnd}}(?!-)'
           beginCaptures:
             0: { name: keyword.operator.word.rosetta }
-          end: '{{qualifiedIdentifier}}'
+          end: '{{qualifiedIdentifier}}|{{rootEnd}}'
           endCaptures:
             0: { name: entity.name.type.rosetta }
           patterns:


### PR DESCRIPTION
Fix TextMate highlighting corruption on 9.x.x caused by a reporting/eligibility rule's trailing `as "label"` clause, e.g. `then extract someField as "Some Report Field Name"`.

The `as`-operator rule in `rosetta.tmLanguage.yaml` assumed every `as` is the type-cast operator (`x as SomeType`) and required an identifier to close its scope, with no fallback. When `as` is followed by a string instead, the scanner runs forward past it looking for an identifier, latches onto the first identifier-shaped word inside the string itself, and desyncs the highlighter's tracking of string boundaries — corrupting highlighting for everything downstream until it happens to resynchronize. A later, unrelated `reporting rule` keyword can end up unhighlighted, and words inside a later string literal can pick up keyword-like coloring.

This regressed in be4c07e0 (#1246), which added highlighting for the new expression-level type-cast `as` operator directly on 9.x.x (not a backport from `main`) without accounting for the pre-existing rule-label use of `as`. Before that commit, `as` was just one entry in a plain single-token keyword list with no scope to run away, so the rule label case always highlighted correctly.

Fix: add a dedicated pattern that matches `as` followed by a quote, coloring just the keyword and leaving the string to the existing string pattern. Also add a `{{rootEnd}}` fallback to the type-cast rule's `end` pattern so it can't run away like this again.

Verified with `vscode-textmate` against the generated grammar: reproduced the exact corruption on the pre-fix grammar using a two-rule sample matching the report, confirmed clean highlighting on both rules after the fix. `GenerateTmGrammar`'s own validation (`mvn -pl rune-ide process-classes`) still passes.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
