### PR TITLE
Enable OSS Index analyzer in CVE scanning

### DIFF
--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -92,7 +92,9 @@ jobs:
             -Dformats=HTML \
             -DoutputDirectory=reports \
             -DfailBuildOnCVSS=7 \
-            -DossIndexAnalyzerEnabled=false \
+            -DossIndexAnalyzerEnabled=true \
+            -DossIndexUsername=${{ secrets.OSSINDEX_USERNAME }} \
+            -DossIndexPassword=${{ secrets.OSSINDEX_TOKEN }} \
             -DnodeAuditAnalyzerEnabled=false
       - name: Upload results
         if: always()

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <slf4j.version>2.0.13</slf4j.version>
         <logback.version>1.5.25</logback.version>
         <InMemoryJavaCompiler.version>1.3.0</InMemoryJavaCompiler.version>
-        <jackson.version>2.18.8</jackson.version>
+        <jackson.version>2.18.10</jackson.version>
         <guice.version>6.0.0</guice.version>
 
         <!-- test -->


### PR DESCRIPTION
Enables the Sonatype OSS Index analyzer in the CVE scanning workflow

OSS Index reports vulnerabilities that are not yet in the NVD dataset, so this catches CVEs the current NVD-only scan misses (e.g. a very recently published CVE). `nodeAuditAnalyzerEnabled` is left disabled.

Needs `OSSINDEX_USERNAME`/`OSSINDEX_TOKEN` repo secrets to actually take effect — without them dependency-check silently disables the analyzer (no failure, just a no-op) per the [OWASP docs](https://dependency-check.github.io/DependencyCheck/analyzers/oss-index-analyzer.html). Please add those secrets if not already present.
