### PR TITLE
Run CVE scan schedule Mon/Wed/Fri and rename OSS Index secrets

### DIFF
--- a/.github/workflows/cve-scanning-schedule.yml
+++ b/.github/workflows/cve-scanning-schedule.yml
@@ -8,10 +8,10 @@ name: CVE Scanning Schedule
 on:
   workflow_dispatch:
   schedule:
-    # Run daily to catch newly published CVEs even without repo changes.
+    # Run Mon/Wed/Fri to catch newly published CVEs even without repo changes.
     # Staggered across repos (rune-dsl 01:00, rune-common 01:30, rune-testing
     # 02:00) to avoid all three hitting the NVD API / shared runners at once.
-    - cron: '0 1 * * *'
+    - cron: '0 1 * * 1,3,5'
 
 # Neither step below uses the default GITHUB_TOKEN, so it's granted no
 # permissions at all.

--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -93,8 +93,8 @@ jobs:
             -DoutputDirectory=reports \
             -DfailBuildOnCVSS=7 \
             -DossIndexAnalyzerEnabled=true \
-            -DossIndexUsername=${{ secrets.OSSINDEX_USERNAME }} \
-            -DossIndexPassword=${{ secrets.OSSINDEX_TOKEN }} \
+            -DossIndexUsername=${{ secrets.OSS_INDEX_USERNAME }} \
+            -DossIndexPassword=${{ secrets.OSS_INDEX_TOKEN }} \
             -DnodeAuditAnalyzerEnabled=false
       - name: Upload results
         if: always()

--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       scheduled:
-        description: 'Set by cve-scanning-schedule.yml when dispatching this run from the daily cron'
+        description: 'Set by cve-scanning-schedule.yml when dispatching this run from the scheduled cron'
         type: boolean
         default: false
   push:


### PR DESCRIPTION
## Summary
- CVE scan schedule (`cve-scanning-schedule.yml`) now runs Mon/Wed/Fri at 01:00 UTC instead of daily.
- Renamed the OSS Index secrets referenced in `cve-scanning.yml` from `OSSINDEX_USERNAME`/`OSSINDEX_TOKEN` to `OSS_INDEX_USERNAME`/`OSS_INDEX_TOKEN`.
   - This is to match FINOS' secret names - they have currently run out of OSS API tokens but when they get more we can just delete out secrets overrides, and fall back to their credentials

## Test plan
- [ ] Repo secrets `OSS_INDEX_USERNAME` and `OSS_INDEX_TOKEN` are added before/at merge (old `OSSINDEX_*` names can then be removed)
- [ ] Confirm the scheduled dispatch (`cve-scanning-schedule.yml`) fires only on Mon/Wed/Fri after merge