### PR TITLE
Format label, rule reference and transform annotations, and allow qualified names in annotations

### DIFF
--- a/rune-ide/rosetta.tmLanguage.yaml
+++ b/rune-ide/rosetta.tmLanguage.yaml
@@ -626,7 +626,7 @@ repository:
           patterns:
           - include: '#comment'
           - include: '#annotationPath'
-          - begin: '{{identifier}}'
+          - begin: '{{qualifiedIdentifier}}'
             beginCaptures:
               0: { name: entity.name.document.body.rosetta }
             end: '{{docReferenceAnnotationSectionEnd}}'
@@ -634,7 +634,7 @@ repository:
             - include: '#comment'
             - include: '#string'
             - name: entity.name.document.rosetta # need semantic tokens to distinguish between corpus and segment
-              match: '{{identifier}}'
+              match: '{{qualifiedIdentifier}}'
         - name: keyword.other.rosetta
           match: '{{docReferenceAnnotationSection}}'
         - include: '#string'
@@ -649,7 +649,7 @@ repository:
         - include: '#comment'
         - include: '#annotationPath'
         - name: entity.name.rule.rosetta
-          match: '{{identifier}}'
+          match: '{{qualifiedIdentifier}}'
 
       labelAnnotationBody:
         name: meta.annotated.label.rosetta

--- a/rune-ide/rosetta.tmLanguage.yaml
+++ b/rune-ide/rosetta.tmLanguage.yaml
@@ -585,8 +585,9 @@ repository:
         - include: '#comment'
         # The reference may be either a serialization-format enum value or a schema name,
         # so use a generic identifier scope rather than an enum-member-specific one.
+        # A schema may be referred to by its qualified name.
         - name: variable.other.rosetta
-          match: '{{identifier}}'
+          match: '{{qualifiedIdentifier}}'
 
       prefixAnnotationBody:
         name: meta.annotated.prefix.rosetta
@@ -678,7 +679,7 @@ repository:
 
       customAnnotationBody:
         name: meta.annotated.rosetta
-        begin: '{{identifier}}'
+        begin: '{{qualifiedIdentifier}}'
         beginCaptures:
           0: { name: variable.annotation.rosetta }
         end: (?=\])|{{sectionEnd}}

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/formatting2/RosettaFormattingTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/formatting2/RosettaFormattingTest.java
@@ -683,4 +683,162 @@ public class RosettaFormattingTest {
 					B
 				""");
 	}
+
+	@Test
+	void testLabelAnnotationOnAttribute() {
+		formatAndAssert("""
+				namespace test
+
+				type Foo:
+					bar Bar (1..1)  [  label  "My label"  ]  [ label for  baz -> qux   "Other label" ]
+				""", """
+				namespace test
+
+				type Foo:
+					bar Bar (1..1)
+						[label "My label"]
+						[label for baz -> qux "Other label"]
+				""");
+	}
+
+	@Test
+	void testRuleReferenceAnnotationOnAttribute() {
+		formatAndAssert("""
+				namespace test
+
+				type Foo:
+					bar Bar (1..1)  [ ruleReference   MyRule ]   [ruleReference  for baz ->> qux  empty]
+				""", """
+				namespace test
+
+				type Foo:
+					bar Bar (1..1)
+						[ruleReference MyRule]
+						[ruleReference for baz ->> qux empty]
+				""");
+	}
+
+	@Test
+	void testAnnotationsOnChoiceOption() {
+		formatAndAssert("""
+				namespace test
+
+				choice Foo:
+					Bar  [ label  "My label" ]
+					Qux
+				""", """
+				namespace test
+
+				choice Foo:
+					Bar
+						[label "My label"]
+					Qux
+				""");
+	}
+
+	@Test
+	void testTransformAnnotationsOnFunction() {
+		formatAndAssert("""
+				namespace test
+
+				func Foo:  [ ingest   FpML ]  [ enrich ]  [projection  XML]
+					output:
+						result Bar (1..1)
+				""", """
+				namespace test
+
+				func Foo:
+					[ingest FpML]
+					[enrich]
+					[projection XML]
+					output:
+						result Bar (1..1)
+				""");
+	}
+
+	@Test
+	void testRuleReferenceInRuleSource() {
+		formatAndAssert("""
+				namespace test
+
+				rule source TestSource {
+					Foo:
+						+ bar
+							[ ruleReference   MyRule ]
+				}
+				""", """
+				namespace test
+
+				rule source TestSource
+				{
+					Foo:
+						+ bar
+							[ruleReference MyRule]
+				}
+				""");
+	}
+
+	@Test
+	void testAnnotationRefWithQualifier() {
+		formatAndAssert("""
+				namespace test
+
+				type Foo:
+					bar Bar (1..1)  [ metadata  address   "pointsTo" = Bar -> baz ]
+				""", """
+				namespace test
+
+				type Foo:
+					bar Bar (1..1)
+						[metadata address "pointsTo"=Bar->baz]
+				""");
+	}
+
+	@Test
+	void testAnnotationsOnEnumValueAndChoice() {
+		formatAndAssert("""
+				namespace test
+
+				choice Foo:  [ deprecated ]
+					Bar
+
+				enum Baz:
+					VALUE  [ deprecated ]
+				""", """
+				namespace test
+
+				choice Foo:
+					[deprecated]
+					Bar
+
+				enum Baz:
+					VALUE
+						[deprecated]
+				""");
+	}
+
+	@Test
+	void testAnnotationsWithQualifiedNames() {
+		formatAndAssert("""
+				namespace test
+
+				type Foo:  [ test.annotations.myAnnotation ]
+					bar Bar (1..1)
+
+				func Ingest:  [ ingest  test.formats.MySchema ]
+					output:
+						result Foo (1..1)
+				""", """
+				namespace test
+
+				type Foo:
+					[test.annotations.myAnnotation]
+					bar Bar (1..1)
+
+				func Ingest:
+					[ingest test.formats.MySchema]
+					output:
+						result Foo (1..1)
+				""");
+	}
 }

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/formatting2/RosettaFormattingTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/formatting2/RosettaFormattingTest.java
@@ -825,7 +825,7 @@ public class RosettaFormattingTest {
 				type Foo:  [ test.annotations.myAnnotation ]
 					bar Bar (1..1)
 
-				func Ingest:  [ ingest  test.formats.MySchema ]
+				func Ingest:  [ ingest  test.formats.mySchema ]
 					output:
 						result Foo (1..1)
 				""", """
@@ -836,9 +836,73 @@ public class RosettaFormattingTest {
 					bar Bar (1..1)
 
 				func Ingest:
-					[ingest test.formats.MySchema]
+					[ingest test.formats.mySchema]
 					output:
 						result Foo (1..1)
+				""");
+	}
+
+	@Test
+	void testEmptyRuleReferenceAnnotationOnAttribute() {
+		formatAndAssert("""
+				namespace test
+
+				type Foo:
+					bar Bar (1..1)  [ ruleReference   empty ]
+				""", """
+				namespace test
+
+				type Foo:
+					bar Bar (1..1)
+						[ruleReference empty]
+				""");
+	}
+
+	@Test
+	void testAnnotationOnEnumDeclaration() {
+		formatAndAssert("""
+				namespace test
+
+				enum Foo:  [ deprecated ]
+					VALUE
+				""", """
+				namespace test
+
+				enum Foo:
+					[deprecated]
+					VALUE
+				""");
+	}
+
+	@Test
+	void testDocReferenceOnCondition() {
+		formatAndAssert("""
+				namespace test
+
+				body Authority ESMA
+				corpus Regulation "600/2014" MiFIR
+				segment article
+
+				type Foo:
+					bar string (1..1)
+
+					condition BarExists:  [docReference ESMA MiFIR article "1"]
+						bar exists
+				""", """
+				namespace test
+
+				body Authority ESMA
+
+				corpus Regulation "600/2014" MiFIR
+
+				segment article
+
+				type Foo:
+					bar string (1..1)
+
+					condition BarExists:
+						[docReference ESMA MiFIR article "1"]
+						bar exists
 				""");
 	}
 }

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/parsing/RosettaCrossReferencingTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/parsing/RosettaCrossReferencingTest.java
@@ -104,7 +104,7 @@ public class RosettaCrossReferencingTest {
 		String schemaModel = """
 			namespace test.formats
 			
-			schema MySchema XML
+			schema mySchema XML
 			""";
 		
 		String functionModel = """
@@ -114,7 +114,7 @@ public class RosettaCrossReferencingTest {
 				n int (1..1)
 			
 			func Ingest:
-				[ingest test.formats.MySchema]
+				[ingest test.formats.mySchema]
 				inputs:
 					input string (1..1)
 				output:

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/parsing/RosettaCrossReferencingTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/parsing/RosettaCrossReferencingTest.java
@@ -98,4 +98,49 @@ public class RosettaCrossReferencingTest {
 		modelHelper.parseRosettaWithNoIssues(model1, model2);
 		modelHelper.parseRosettaWithNoIssues(model2, model1);
 	}
+
+	@Test
+	void testFullyQualifiedSchemaCanBeUsedInTransformAnnotation() {
+		String schemaModel = """
+			namespace test.formats
+			
+			schema MySchema XML
+			""";
+		
+		String functionModel = """
+			namespace test.foo
+			
+			type Bar:
+				n int (1..1)
+			
+			func Ingest:
+				[ingest test.formats.MySchema]
+				inputs:
+					input string (1..1)
+				output:
+					result Bar (1..1)
+				set result -> n: 1
+			""";
+		
+		modelHelper.parseRosettaWithNoIssues(schemaModel, functionModel);
+	}
+	
+	@Test
+	void testFullyQualifiedAnnotationCanBeUsedInAnnotationRef() {
+		String annotationModel = """
+			namespace test.annotations
+			
+			annotation myAnnotation: <"An annotation.">
+			""";
+		
+		String typeModel = """
+			namespace test.foo
+			
+			type A:
+				[test.annotations.myAnnotation]
+				n int (1..1)
+			""";
+		
+		modelHelper.parseRosettaWithNoIssues(annotationModel, typeModel);
+	}
 }

--- a/rune-lang/src/main/java/com/regnosys/rosetta/Rosetta.xtext
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/Rosetta.xtext
@@ -733,7 +733,9 @@ RosettaReport:
 ;
 
 RuleReferenceAnnotation:
-	'[' name='ruleReference' ('for' path=AnnotationPathExpression)? (reportingRule=[RosettaRule|QualifiedName] | empty?='empty') ']'	
+	// The action is necessary so that `[ruleReference empty]`, whose only assignments are keywords,
+	// gets a region in the formatter's region access - without it, the formatter cannot format it.
+	{RuleReferenceAnnotation} '[' name='ruleReference' ('for' path=AnnotationPathExpression)? (reportingRule=[RosettaRule|QualifiedName] | empty?='empty') ']'	
 ;
 
 RosettaRule:

--- a/rune-lang/src/main/java/com/regnosys/rosetta/Rosetta.xtext
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/Rosetta.xtext
@@ -56,7 +56,7 @@ fragment RuleReference*:
 // - docReference
 // - ruleReference
 AnnotationRef:
-	'[' annotation = [Annotation|ValidID] (attribute = [Attribute|ValidID] (qualifiers += AnnotationQualifier)*)? ']'
+	'[' annotation = [Annotation|QualifiedName] (attribute = [Attribute|ValidID] (qualifiers += AnnotationQualifier)*)? ']'
 ;
 
 AnnotationQualifier:
@@ -182,7 +182,7 @@ enum TransformKind:
 ;
 
 TransformAnnotation:
-	'[' kind=TransformKind (ref=[SchemaOrFormat|ValidID])? ']'
+	'[' kind=TransformKind (ref=[SchemaOrFormat|QualifiedName])? ']'
 ;
 
 

--- a/rune-lang/src/main/java/com/regnosys/rosetta/formatting2/RosettaFormatter.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/formatting2/RosettaFormatter.java
@@ -42,18 +42,22 @@ import com.regnosys.rosetta.rosetta.TypeCall;
 import com.regnosys.rosetta.rosetta.TypeCallArgument;
 import com.regnosys.rosetta.rosetta.TypeParameter;
 import com.regnosys.rosetta.rosetta.expression.RosettaExpression;
-import com.regnosys.rosetta.rosetta.simple.Annotated;
 import com.regnosys.rosetta.rosetta.simple.Annotation;
+import com.regnosys.rosetta.rosetta.simple.AnnotationQualifier;
 import com.regnosys.rosetta.rosetta.simple.AnnotationRef;
 import com.regnosys.rosetta.rosetta.simple.Attribute;
+import com.regnosys.rosetta.rosetta.simple.BuiltinAnnotation;
 import com.regnosys.rosetta.rosetta.simple.Choice;
 import com.regnosys.rosetta.rosetta.simple.Condition;
 import com.regnosys.rosetta.rosetta.simple.Data;
 import com.regnosys.rosetta.rosetta.simple.Function;
 import com.regnosys.rosetta.rosetta.simple.FunctionDispatch;
+import com.regnosys.rosetta.rosetta.simple.LabelAnnotation;
 import com.regnosys.rosetta.rosetta.simple.Operation;
+import com.regnosys.rosetta.rosetta.simple.RuleReferenceAnnotation;
 import com.regnosys.rosetta.rosetta.simple.Segment;
 import com.regnosys.rosetta.rosetta.simple.ShortcutDeclaration;
+import com.regnosys.rosetta.rosetta.simple.TransformAnnotation;
 import com.regnosys.rosetta.services.RosettaGrammarAccess;
 
 import jakarta.inject.Inject;
@@ -279,6 +283,7 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 		document.prepend(regionFor(ele).keyword(":"), IHiddenRegionFormatter::noSpace);
 		formattingUtil.indentInner(ele, document);
 		formatDefinition(ele, document);
+		formatAnnotations(ele, document);
 		Attribute firstAttribute = headOrNull(ele.getAttributes());
 		if (firstAttribute != null) {
 			document.format(document.prepend(firstAttribute, f -> f.setNewLines(1, 2, 2)));
@@ -298,10 +303,6 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 		formatDefinition(ele, document);
 		formattingUtil.indentInner(ele, document);
 		formatAnnotations(ele, document);
-		ele.getReferences().forEach(ref -> {
-			document.prepend(ref, IHiddenRegionFormatter::newLine);
-			document.format(ref);
-		});
 		Attribute firstAttribute = headOrNull(ele.getAttributes());
 		if (firstAttribute != null) {
 			document.format(document.prepend(firstAttribute, f -> f.setNewLines(1, 2, 2)));
@@ -348,10 +349,6 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 		formattingUtil.indentInner(ele, document);
 		document.format(document.surround(ele.getTypeCall(), IHiddenRegionFormatter::oneSpace));
 		formatDefinition(ele, document);
-		ele.getReferences().forEach(ref -> {
-			document.prepend(ref, IHiddenRegionFormatter::newLine);
-			document.format(ref);
-		});
 		formatAnnotations(ele, document);
 	}
 
@@ -388,11 +385,27 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 		document.format(document.prepend(ele.getExpression(), IHiddenRegionFormatter::newLine));
 	}
 
-	private void formatAnnotations(Annotated ele, IFormattableDocument document) {
-		ele.getAnnotations().forEach(ann -> {
-			document.prepend(ann, IHiddenRegionFormatter::newLine);
-			document.format(ann);
-		});
+	/**
+	 * Formats every annotation of {@code ele} on a line of its own: annotation references such as
+	 * {@code [metadata scheme]}, doc references, labels, rule references and transform annotations.
+	 * <p>
+	 * This iterates over the actual contents of {@code ele} rather than over a fixed list of features,
+	 * so an element that gains another kind of annotation is formatted without a change to this class.
+	 */
+	private void formatAnnotations(EObject ele, IFormattableDocument document) {
+		ele.eContents().stream()
+				.filter(RosettaFormatter::isAnnotation)
+				.forEach(annotation -> {
+					document.prepend(annotation, IHiddenRegionFormatter::newLine);
+					document.format(annotation);
+				});
+	}
+
+	private static boolean isAnnotation(EObject ele) {
+		return ele instanceof AnnotationRef
+				|| ele instanceof BuiltinAnnotation
+				|| ele instanceof RosettaDocReference
+				|| ele instanceof TransformAnnotation;
 	}
 
 	private RosettaDefinable formatDefinition(RosettaDefinable ele, IFormattableDocument document) {
@@ -418,6 +431,40 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 		document.append(regionFor(ele).keyword(annotationRefGrammarAccess.getLeftSquareBracketKeyword_0()), NO_SPACE);
 		document.prepend(regionFor(ele).keyword(annotationRefGrammarAccess.getRightSquareBracketKeyword_3()), NO_SPACE);
 		document.prepend(regionFor(ele).assignment(annotationRefGrammarAccess.getAttributeAssignment_2_0()), ONE_SPACE);
+		ele.getQualifiers().forEach(qualifier -> {
+			document.prepend(qualifier, ONE_SPACE);
+			document.format(qualifier);
+		});
+	}
+
+	private void format(AnnotationQualifier ele, IFormattableDocument document) {
+		document.surround(regionFor(ele).keyword("="), NO_SPACE);
+		allRegionsFor(ele).keywords("->").forEach(arrow -> document.surround(arrow, NO_SPACE));
+	}
+
+	private void format(LabelAnnotation ele, IFormattableDocument document) {
+		formatSingleLineAnnotation(ele, document);
+	}
+
+	private void format(RuleReferenceAnnotation ele, IFormattableDocument document) {
+		formatSingleLineAnnotation(ele, document);
+	}
+
+	private void format(TransformAnnotation ele, IFormattableDocument document) {
+		formatSingleLineAnnotation(ele, document);
+	}
+
+	/**
+	 * Formats an annotation that always fits on one line, e.g. {@code [label for foo -> bar "My label"]}:
+	 * no space just inside the brackets, a single space between all other tokens.
+	 */
+	private void formatSingleLineAnnotation(EObject ele, IFormattableDocument document) {
+		ISemanticRegion open = regionFor(ele).keyword("[");
+		ISemanticRegion close = regionFor(ele).keyword("]");
+		document.append(open, NO_SPACE);
+		document.prepend(close, NO_SPACE);
+		formattingUtil.singleSpacesUntil(document, open.getNextHiddenRegion().getNextHiddenRegion(),
+				close.getPreviousHiddenRegion());
 	}
 
 	private void format(Function ele, IFormattableDocument document) {
@@ -449,10 +496,6 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 
 		formattingUtil.indentInner(ele, document);
 
-		ele.getReferences().forEach(ref -> {
-			document.prepend(ref, IHiddenRegionFormatter::newLine);
-			document.format(ref);
-		});
 		formatAnnotations(ele, document);
 
 		ISemanticRegion inputsKW = regionFor(ele).keyword(functionGrammarAccess.getInputsKeyword_6_0());
@@ -603,10 +646,7 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 		formatDefinition(ele, document);
 		formattingUtil.indentInner(ele, document);
 
-		ele.getReferences().forEach(ref -> {
-			document.prepend(ref, IHiddenRegionFormatter::newLine);
-			document.format(ref);
-		});
+		formatAnnotations(ele, document);
 		RosettaEnumValue firstEnumValue = headOrNull(ele.getEnumValues());
 		if (firstEnumValue != null) {
 			document.format(document.prepend(firstEnumValue, f -> f.setNewLines(1, 2, 2)));
@@ -619,10 +659,7 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 
 	private void format(RosettaEnumValue rosettaEnumValue, IFormattableDocument document) {
 		formattingUtil.indentInner(formatDefinition(rosettaEnumValue, document), document);
-		rosettaEnumValue.getReferences().forEach(ref -> {
-			document.prepend(ref, IHiddenRegionFormatter::newLine);
-			document.format(ref);
-		});
+		formatAnnotations(rosettaEnumValue, document);
 	}
 
 	private void format(RosettaExpression ele, IFormattableDocument document) {
@@ -651,10 +688,7 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 
 		formattingUtil.indentInner(ele, document);
 
-		ele.getReferences().forEach(ref -> { // TODO: format references
-			document.prepend(ref, IHiddenRegionFormatter::newLine);
-			document.format(ref);
-		});
+		formatAnnotations(ele, document);
 
 		document.format(document.prepend(ele.getExpression(), IHiddenRegionFormatter::newLine));
 	}
@@ -693,10 +727,7 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 						.feature(RosettaPackage.Literals.ROSETTA_EXTERNAL_REGULAR_ATTRIBUTE__OPERATOR),
 				IHiddenRegionFormatter::oneSpace);
 		formattingUtil.indentInner(externalRegularAttribute, document);
-		externalRegularAttribute.getExternalRuleReferences().forEach(ref -> {
-			document.prepend(ref, IHiddenRegionFormatter::newLine);
-			document.format(ref);
-		});
+		formatAnnotations(externalRegularAttribute, document);
 	}
 
 	private void indentedBraces(EObject eObject, IFormattableDocument document) {

--- a/rune-lang/src/main/java/com/regnosys/rosetta/formatting2/RosettaFormatter.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/formatting2/RosettaFormatter.java
@@ -390,7 +390,8 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 	 * {@code [metadata scheme]}, doc references, labels, rule references and transform annotations.
 	 * <p>
 	 * This iterates over the actual contents of {@code ele} rather than over a fixed list of features,
-	 * so an element that gains another kind of annotation is formatted without a change to this class.
+	 * so an element that gains one of the existing kinds of annotation is formatted without a change
+	 * here. A new kind of annotation still needs a clause in {@link #isAnnotation}.
 	 */
 	private void formatAnnotations(EObject ele, IFormattableDocument document) {
 		ele.eContents().stream()
@@ -402,9 +403,9 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 	}
 
 	private static boolean isAnnotation(EObject ele) {
+		// RosettaDocReference, LabelAnnotation and RuleReferenceAnnotation are all BuiltinAnnotations.
 		return ele instanceof AnnotationRef
 				|| ele instanceof BuiltinAnnotation
-				|| ele instanceof RosettaDocReference
 				|| ele instanceof TransformAnnotation;
 	}
 


### PR DESCRIPTION
## Formatting

`[label ...]`, `[ruleReference ...]` and `[ingest|enrich|projection ...]` were never formatted: the formatter left their whitespace exactly as written, and did not put them on a line of their own.

The cause is the shape of `RosettaFormatter`: each `format(...)` method listed the features that hold annotations (`getReferences()`, `getAnnotations()`), so the features added to the grammar later were simply not visited. `formatAnnotations` now iterates over the actual contents of an element and formats every child that is an annotation, so this class of omission does not recur when another annotation kind is added — only `isAnnotation` needs to know about it. That also picked up three gaps nobody had reported: annotations on an enum value, annotations on a `choice`, and the spacing inside an annotation qualifier (`[metadata address "pointsTo"=Bar->baz]`).

## Qualified names

`[ingest my.model.MySchema]` did not parse — `TransformAnnotation` accepted a simple name only. The same held for annotation references: `[my.annotations.myAnnotation]`. Scoping already resolves qualified names for both (the transform ref falls back to the global scope, the annotation ref uses the default scope), so only the parser rules changed.

No other cross-reference needs the same change. Every one still parsed with `ValidID` points at something resolved locally — an attribute of the enclosing type, a function input, an enum value within its enum, a schema format within the built-in `SerializationFormat` enum — where a qualified name has no meaning.

One neighbouring limitation is left alone: `schema` is a keyword that is not part of `ValidID`, so nothing can be named `schema` (a namespace segment `my.model.schema`, or an attribute). Adding it to `ValidID` leaves the parser generated from `Rosetta.xtext` unable to tell a `schema` root element from an attribute named `schema`: the build reports the ambiguity and silently disables one of the two alternatives. So it needs more than a one-line change.

## Testing

`RosettaFormatter` is covered by the 8 tests added to `RosettaFormattingTest`, one per construct changed: label and rule reference annotations on an attribute and on a choice option, transform annotations on a function, rule references in a rule source, annotation qualifiers, annotations on an enum value and on a choice, and qualified names in both annotation kinds. Each of them fails on `main` and passes here. They run with `allowUnformattedWhitespace(false)`, so they also fail if any whitespace in the model is left unformatted. The grammar change is covered by two tests in `RosettaCrossReferencingTest`.

`mvnd install` — full build, all tests, checkstyle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4phbXShAy8iBNdpmrraoZ
