### PR TITLE
[9.x.x] Format label, rule reference and transform annotations, and allow qualified names in annotations (#1381)

### DIFF
--- a/rune-ide/rosetta.tmLanguage.yaml
+++ b/rune-ide/rosetta.tmLanguage.yaml
@@ -622,8 +622,9 @@ repository:
         - include: '#comment'
         # The reference may be either a serialization-format enum value or a schema name,
         # so use a generic identifier scope rather than an enum-member-specific one.
+        # A schema may be referred to by its qualified name.
         - name: variable.other.rosetta
-          match: '{{identifier}}'
+          match: '{{qualifiedIdentifier}}'
 
       prefixAnnotationBody:
         name: meta.annotated.prefix.rosetta
@@ -721,7 +722,7 @@ repository:
           patterns:
           - include: '#comment'
           - include: '#annotationPath'
-          - begin: '{{identifier}}'
+          - begin: '{{qualifiedIdentifier}}'
             beginCaptures:
               0: { name: entity.name.document.body.rosetta }
             end: '{{docReferenceAnnotationSectionEnd}}'
@@ -729,7 +730,7 @@ repository:
             - include: '#comment'
             - include: '#string'
             - name: entity.name.document.rosetta # need semantic tokens to distinguish between corpus and segment
-              match: '{{identifier}}'
+              match: '{{qualifiedIdentifier}}'
         - name: keyword.other.rosetta
           match: '{{docReferenceAnnotationSection}}'
         - include: '#string'
@@ -744,7 +745,7 @@ repository:
         - include: '#comment'
         - include: '#annotationPath'
         - name: entity.name.rule.rosetta
-          match: '{{identifier}}'
+          match: '{{qualifiedIdentifier}}'
 
       labelAnnotationBody:
         name: meta.annotated.label.rosetta
@@ -774,7 +775,7 @@ repository:
 
       customAnnotationBody:
         name: meta.annotated.rosetta
-        begin: '{{identifier}}'
+        begin: '{{qualifiedIdentifier}}'
         beginCaptures:
           0: { name: variable.annotation.rosetta }
         end: (?=\])|{{sectionEnd}}

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/formatting2/RosettaFormattingTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/formatting2/RosettaFormattingTest.java
@@ -691,6 +691,39 @@ public class RosettaFormattingTest {
 	}
 
 	@Test
+	void formatSynonymOnChoiceAndOnExternalEnumValue() {
+		formatAndAssert("""
+				namespace test
+
+				choice Foo:  [ synonym  SynSource  value "foo" ]
+					Bar  [ synonym  SynSource  value "bar" ]
+
+				synonym source MySource {
+					enums
+					MyEnum:
+					+ VALUE
+					[ value  "my_value" ]
+				}
+				""", """
+				namespace test
+
+				choice Foo:
+					[synonym SynSource value "foo"]
+					Bar
+						[synonym SynSource value "bar"]
+
+				synonym source MySource
+				{
+					enums
+
+					MyEnum:
+						+ VALUE
+							[value "my_value"]
+				}
+				""");
+	}
+
+	@Test
 	void formatAttributeSynomym() {
 		formatAndAssert("""
 				namespace "test"
@@ -831,6 +864,228 @@ public class RosettaFormattingTest {
 				choice Test:
 					A
 					B
+				""");
+	}
+
+	@Test
+	void testLabelAnnotationOnAttribute() {
+		formatAndAssert("""
+				namespace test
+
+				type Foo:
+					bar Bar (1..1)  [  label  "My label"  ]  [ label for  baz -> qux   "Other label" ]
+				""", """
+				namespace test
+
+				type Foo:
+					bar Bar (1..1)
+						[label "My label"]
+						[label for baz -> qux "Other label"]
+				""");
+	}
+
+	@Test
+	void testRuleReferenceAnnotationOnAttribute() {
+		formatAndAssert("""
+				namespace test
+
+				type Foo:
+					bar Bar (1..1)  [ ruleReference   MyRule ]   [ruleReference  for baz ->> qux  empty]
+				""", """
+				namespace test
+
+				type Foo:
+					bar Bar (1..1)
+						[ruleReference MyRule]
+						[ruleReference for baz ->> qux empty]
+				""");
+	}
+
+	@Test
+	void testAnnotationsOnChoiceOption() {
+		formatAndAssert("""
+				namespace test
+
+				choice Foo:
+					Bar  [ label  "My label" ]
+					Qux
+				""", """
+				namespace test
+
+				choice Foo:
+					Bar
+						[label "My label"]
+					Qux
+				""");
+	}
+
+	@Test
+	void testTransformAnnotationsOnFunction() {
+		formatAndAssert("""
+				namespace test
+
+				func Foo:  [ ingest   FpML ]  [ enrich ]  [projection  XML]
+					output:
+						result Bar (1..1)
+				""", """
+				namespace test
+
+				func Foo:
+					[ingest FpML]
+					[enrich]
+					[projection XML]
+					output:
+						result Bar (1..1)
+				""");
+	}
+
+	@Test
+	void testRuleReferenceInRuleSource() {
+		formatAndAssert("""
+				namespace test
+
+				rule source TestSource {
+					Foo:
+						+ bar
+							[ ruleReference   MyRule ]
+				}
+				""", """
+				namespace test
+
+				rule source TestSource
+				{
+					Foo:
+						+ bar
+							[ruleReference MyRule]
+				}
+				""");
+	}
+
+	@Test
+	void testAnnotationRefWithQualifier() {
+		formatAndAssert("""
+				namespace test
+
+				type Foo:
+					bar Bar (1..1)  [ metadata  address   "pointsTo" = Bar -> baz ]
+				""", """
+				namespace test
+
+				type Foo:
+					bar Bar (1..1)
+						[metadata address "pointsTo"=Bar->baz]
+				""");
+	}
+
+	@Test
+	void testAnnotationsOnEnumValueAndChoice() {
+		formatAndAssert("""
+				namespace test
+
+				choice Foo:  [ deprecated ]
+					Bar
+
+				enum Baz:
+					VALUE  [ deprecated ]
+				""", """
+				namespace test
+
+				choice Foo:
+					[deprecated]
+					Bar
+
+				enum Baz:
+					VALUE
+						[deprecated]
+				""");
+	}
+
+	@Test
+	void testAnnotationsWithQualifiedNames() {
+		formatAndAssert("""
+				namespace test
+
+				type Foo:  [ test.annotations.myAnnotation ]
+					bar Bar (1..1)
+
+				func Ingest:  [ ingest  test.formats.mySchema ]
+					output:
+						result Foo (1..1)
+				""", """
+				namespace test
+
+				type Foo:
+					[test.annotations.myAnnotation]
+					bar Bar (1..1)
+
+				func Ingest:
+					[ingest test.formats.mySchema]
+					output:
+						result Foo (1..1)
+				""");
+	}
+
+	@Test
+	void testEmptyRuleReferenceAnnotationOnAttribute() {
+		formatAndAssert("""
+				namespace test
+
+				type Foo:
+					bar Bar (1..1)  [ ruleReference   empty ]
+				""", """
+				namespace test
+
+				type Foo:
+					bar Bar (1..1)
+						[ruleReference empty]
+				""");
+	}
+
+	@Test
+	void testAnnotationOnEnumDeclaration() {
+		formatAndAssert("""
+				namespace test
+
+				enum Foo:  [ deprecated ]
+					VALUE
+				""", """
+				namespace test
+
+				enum Foo:
+					[deprecated]
+					VALUE
+				""");
+	}
+
+	@Test
+	void testDocReferenceOnCondition() {
+		formatAndAssert("""
+				namespace test
+
+				body Authority ESMA
+				corpus Regulation "600/2014" MiFIR
+				segment article
+
+				type Foo:
+					bar string (1..1)
+
+					condition BarExists:  [docReference ESMA MiFIR article "1"]
+						bar exists
+				""", """
+				namespace test
+
+				body Authority ESMA
+
+				corpus Regulation "600/2014" MiFIR
+
+				segment article
+
+				type Foo:
+					bar string (1..1)
+
+					condition BarExists:
+						[docReference ESMA MiFIR article "1"]
+						bar exists
 				""");
 	}
 }

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/parsing/RosettaCrossReferencingTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/parsing/RosettaCrossReferencingTest.java
@@ -98,4 +98,49 @@ public class RosettaCrossReferencingTest {
 		modelHelper.parseRosettaWithNoIssues(model1, model2);
 		modelHelper.parseRosettaWithNoIssues(model2, model1);
 	}
+
+	@Test
+	void testFullyQualifiedSchemaCanBeUsedInTransformAnnotation() {
+		String schemaModel = """
+			namespace test.formats
+			
+			schema mySchema XML
+			""";
+		
+		String functionModel = """
+			namespace test.foo
+			
+			type Bar:
+				n int (1..1)
+			
+			func Ingest:
+				[ingest test.formats.mySchema]
+				inputs:
+					input string (1..1)
+				output:
+					result Bar (1..1)
+				set result -> n: 1
+			""";
+		
+		modelHelper.parseRosettaWithNoIssues(schemaModel, functionModel);
+	}
+	
+	@Test
+	void testFullyQualifiedAnnotationCanBeUsedInAnnotationRef() {
+		String annotationModel = """
+			namespace test.annotations
+			
+			annotation myAnnotation: <"An annotation.">
+			""";
+		
+		String typeModel = """
+			namespace test.foo
+			
+			type A:
+				[test.annotations.myAnnotation]
+				n int (1..1)
+			""";
+		
+		modelHelper.parseRosettaWithNoIssues(annotationModel, typeModel);
+	}
 }

--- a/rune-lang/src/main/java/com/regnosys/rosetta/Rosetta.xtext
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/Rosetta.xtext
@@ -64,7 +64,7 @@ fragment RuleReference*:
 // - docReference
 // - ruleReference
 AnnotationRef:
-	'[' annotation = [Annotation|ValidID] (attribute = [Attribute|ValidID] (qualifiers += AnnotationQualifier)*)? ']'
+	'[' annotation = [Annotation|QualifiedName] (attribute = [Attribute|ValidID] (qualifiers += AnnotationQualifier)*)? ']'
 ;
 
 AnnotationQualifier:
@@ -192,7 +192,7 @@ enum TransformKind:
 ;
 
 TransformAnnotation:
-	'[' kind=TransformKind (ref=[SchemaOrFormat|ValidID])? ']'
+	'[' kind=TransformKind (ref=[SchemaOrFormat|QualifiedName])? ']'
 ;
 
 
@@ -925,7 +925,9 @@ RosettaReport:
 ;
 
 RuleReferenceAnnotation:
-	'[' name='ruleReference' ('for' path=AnnotationPathExpression)? (reportingRule=[RosettaRule|QualifiedName] | empty?='empty') ']'	
+	// The action is necessary so that `[ruleReference empty]`, whose only assignments are keywords,
+	// gets a region in the formatter's region access - without it, the formatter cannot format it.
+	{RuleReferenceAnnotation} '[' name='ruleReference' ('for' path=AnnotationPathExpression)? (reportingRule=[RosettaRule|QualifiedName] | empty?='empty') ']'	
 ;
 
 RosettaRule:

--- a/rune-lang/src/main/java/com/regnosys/rosetta/formatting2/RosettaFormatter.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/formatting2/RosettaFormatter.java
@@ -43,6 +43,7 @@ import com.regnosys.rosetta.rosetta.RosettaRule;
 import com.regnosys.rosetta.rosetta.RosettaScope;
 import com.regnosys.rosetta.rosetta.RosettaSegment;
 import com.regnosys.rosetta.rosetta.RosettaSynonym;
+import com.regnosys.rosetta.rosetta.RosettaSynonymBase;
 import com.regnosys.rosetta.rosetta.RosettaSynonymSource;
 import com.regnosys.rosetta.rosetta.Schema;
 import com.regnosys.rosetta.rosetta.RosettaTypeAlias;
@@ -50,18 +51,22 @@ import com.regnosys.rosetta.rosetta.TypeCall;
 import com.regnosys.rosetta.rosetta.TypeCallArgument;
 import com.regnosys.rosetta.rosetta.TypeParameter;
 import com.regnosys.rosetta.rosetta.expression.RosettaExpression;
-import com.regnosys.rosetta.rosetta.simple.Annotated;
 import com.regnosys.rosetta.rosetta.simple.Annotation;
+import com.regnosys.rosetta.rosetta.simple.AnnotationQualifier;
 import com.regnosys.rosetta.rosetta.simple.AnnotationRef;
 import com.regnosys.rosetta.rosetta.simple.Attribute;
+import com.regnosys.rosetta.rosetta.simple.BuiltinAnnotation;
 import com.regnosys.rosetta.rosetta.simple.Choice;
 import com.regnosys.rosetta.rosetta.simple.Condition;
 import com.regnosys.rosetta.rosetta.simple.Data;
 import com.regnosys.rosetta.rosetta.simple.Function;
 import com.regnosys.rosetta.rosetta.simple.FunctionDispatch;
+import com.regnosys.rosetta.rosetta.simple.LabelAnnotation;
 import com.regnosys.rosetta.rosetta.simple.Operation;
+import com.regnosys.rosetta.rosetta.simple.RuleReferenceAnnotation;
 import com.regnosys.rosetta.rosetta.simple.Segment;
 import com.regnosys.rosetta.rosetta.simple.ShortcutDeclaration;
+import com.regnosys.rosetta.rosetta.simple.TransformAnnotation;
 import com.regnosys.rosetta.services.RosettaGrammarAccess;
 
 import jakarta.inject.Inject;
@@ -287,6 +292,7 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 		document.prepend(regionFor(ele).keyword(":"), IHiddenRegionFormatter::noSpace);
 		formattingUtil.indentInner(ele, document);
 		formatDefinition(ele, document);
+		formatAnnotations(ele, document);
 		Attribute firstAttribute = headOrNull(ele.getAttributes());
 		if (firstAttribute != null) {
 			document.format(document.prepend(firstAttribute, f -> f.setNewLines(1, 2, 2)));
@@ -305,15 +311,7 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 		document.prepend(regionFor(ele).keyword(":"), IHiddenRegionFormatter::noSpace);
 		formatDefinition(ele, document);
 		formattingUtil.indentInner(ele, document);
-		ele.getSynonyms().forEach(syn -> {
-			document.prepend(syn, IHiddenRegionFormatter::newLine);
-			document.format(syn);
-		});
 		formatAnnotations(ele, document);
-		ele.getReferences().forEach(ref -> {
-			document.prepend(ref, IHiddenRegionFormatter::newLine);
-			document.format(ref);
-		});
 		Attribute firstAttribute = headOrNull(ele.getAttributes());
 		if (firstAttribute != null) {
 			document.format(document.prepend(firstAttribute, f -> f.setNewLines(1, 2, 2)));
@@ -360,15 +358,7 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 		formattingUtil.indentInner(ele, document);
 		document.format(document.surround(ele.getTypeCall(), IHiddenRegionFormatter::oneSpace));
 		formatDefinition(ele, document);
-		ele.getReferences().forEach(ref -> {
-			document.prepend(ref, IHiddenRegionFormatter::newLine);
-			document.format(ref);
-		});
 		formatAnnotations(ele, document);
-		ele.getSynonyms().forEach(syn -> {
-			document.prepend(syn, IHiddenRegionFormatter::newLine);
-			document.format(syn);
-		});
 	}
 
 	private void format(TypeCall ele, IFormattableDocument document) {
@@ -394,6 +384,10 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 		document.prepend(regionFor(card).keyword(")"), IHiddenRegionFormatter::noSpace);
 	}
 
+	/**
+	 * Formats an annotation that always fits on one line, e.g. {@code [label for foo -> bar "My label"]}:
+	 * no space just inside the brackets, a single space between all other tokens.
+	 */
 	private EObject formatSingleLineAnnotation(EObject annotation, IFormattableDocument document) {
 		ISemanticRegion left = regionFor(annotation).keyword("[");
 		ISemanticRegion right = regionFor(annotation).keyword("]");
@@ -415,11 +409,32 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 		document.format(document.prepend(ele.getExpression(), IHiddenRegionFormatter::newLine));
 	}
 
-	private void formatAnnotations(Annotated ele, IFormattableDocument document) {
-		ele.getAnnotations().forEach(ann -> {
-			document.prepend(ann, IHiddenRegionFormatter::newLine);
-			document.format(ann);
-		});
+	/**
+	 * Formats every annotation of {@code ele} on a line of its own: annotation references such as
+	 * {@code [metadata scheme]}, doc references, labels, rule references, transform annotations and
+	 * synonyms.
+	 * <p>
+	 * This iterates over the actual contents of {@code ele} rather than over a fixed list of features,
+	 * so an element that gains one of the existing kinds of annotation is formatted without a change
+	 * here. A new kind of annotation still needs a clause in {@link #isAnnotation}.
+	 */
+	private void formatAnnotations(EObject ele, IFormattableDocument document) {
+		ele.eContents().stream()
+				.filter(RosettaFormatter::isAnnotation)
+				.forEach(annotation -> {
+					document.prepend(annotation, IHiddenRegionFormatter::newLine);
+					document.format(annotation);
+				});
+	}
+
+	private static boolean isAnnotation(EObject ele) {
+		// RosettaDocReference, LabelAnnotation and RuleReferenceAnnotation are all BuiltinAnnotations.
+		// RosettaSynonymBase covers RosettaSynonym, RosettaClassSynonym and RosettaEnumSynonym.
+		return ele instanceof AnnotationRef
+				|| ele instanceof BuiltinAnnotation
+				|| ele instanceof TransformAnnotation
+				|| ele instanceof RosettaSynonymBase
+				|| ele instanceof RosettaExternalSynonym;
 	}
 
 	private RosettaDefinable formatDefinition(RosettaDefinable ele, IFormattableDocument document) {
@@ -445,6 +460,27 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 		document.append(regionFor(ele).keyword(annotationRefGrammarAccess.getLeftSquareBracketKeyword_0()), NO_SPACE);
 		document.prepend(regionFor(ele).keyword(annotationRefGrammarAccess.getRightSquareBracketKeyword_3()), NO_SPACE);
 		document.prepend(regionFor(ele).assignment(annotationRefGrammarAccess.getAttributeAssignment_2_0()), ONE_SPACE);
+		ele.getQualifiers().forEach(qualifier -> {
+			document.prepend(qualifier, ONE_SPACE);
+			document.format(qualifier);
+		});
+	}
+
+	private void format(AnnotationQualifier ele, IFormattableDocument document) {
+		document.surround(regionFor(ele).keyword("="), NO_SPACE);
+		allRegionsFor(ele).keywords("->").forEach(arrow -> document.surround(arrow, NO_SPACE));
+	}
+
+	private void format(LabelAnnotation ele, IFormattableDocument document) {
+		formatSingleLineAnnotation(ele, document);
+	}
+
+	private void format(RuleReferenceAnnotation ele, IFormattableDocument document) {
+		formatSingleLineAnnotation(ele, document);
+	}
+
+	private void format(TransformAnnotation ele, IFormattableDocument document) {
+		formatSingleLineAnnotation(ele, document);
 	}
 
 	private void format(Function ele, IFormattableDocument document) {
@@ -476,10 +512,6 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 
 		formattingUtil.indentInner(ele, document);
 
-		ele.getReferences().forEach(ref -> {
-			document.prepend(ref, IHiddenRegionFormatter::newLine);
-			document.format(ref);
-		});
 		formatAnnotations(ele, document);
 
 		ISemanticRegion inputsKW = regionFor(ele).keyword(functionGrammarAccess.getInputsKeyword_6_0());
@@ -638,14 +670,7 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 		formatDefinition(ele, document);
 		formattingUtil.indentInner(ele, document);
 
-		ele.getReferences().forEach(ref -> {
-			document.prepend(ref, IHiddenRegionFormatter::newLine);
-			document.format(ref);
-		});
-		ele.getSynonyms().forEach(syn -> {
-			document.prepend(syn, IHiddenRegionFormatter::newLine);
-			document.format(syn);
-		});
+		formatAnnotations(ele, document);
 		RosettaEnumValue firstEnumValue = headOrNull(ele.getEnumValues());
 		if (firstEnumValue != null) {
 			document.format(document.prepend(firstEnumValue, f -> f.setNewLines(1, 2, 2)));
@@ -658,14 +683,7 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 
 	private void format(RosettaEnumValue rosettaEnumValue, IFormattableDocument document) {
 		formattingUtil.indentInner(formatDefinition(rosettaEnumValue, document), document);
-		rosettaEnumValue.getReferences().forEach(ref -> {
-			document.prepend(ref, IHiddenRegionFormatter::newLine);
-			document.format(ref);
-		});
-		rosettaEnumValue.getEnumSynonyms().forEach(syn -> {
-			document.prepend(syn, IHiddenRegionFormatter::newLine);
-			document.format(syn);
-		});
+		formatAnnotations(rosettaEnumValue, document);
 	}
 
 	private void format(RosettaEnumSynonym rosettaEnumSynonym, IFormattableDocument document) {
@@ -702,10 +720,7 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 
 		formattingUtil.indentInner(ele, document);
 
-		ele.getReferences().forEach(ref -> { // TODO: format references
-			document.prepend(ref, IHiddenRegionFormatter::newLine);
-			document.format(ref);
-		});
+		formatAnnotations(ele, document);
 
 		document.format(document.prepend(ele.getExpression(), IHiddenRegionFormatter::newLine));
 		if (ele.getIdentifier() != null) {
@@ -803,10 +818,7 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 						.feature(RosettaPackage.Literals.ROSETTA_EXTERNAL_REGULAR_ATTRIBUTE__OPERATOR),
 				IHiddenRegionFormatter::oneSpace);
 		formattingUtil.indentInner(externalRegularAttribute, document);
-		externalRegularAttribute.getExternalSynonyms().forEach(syn -> {
-			document.prepend(syn, IHiddenRegionFormatter::newLine);
-			document.format(syn);
-		});
+		formatAnnotations(externalRegularAttribute, document);
 	}
 
 	private void format(RosettaExternalEnumValue externalEnumValue, IFormattableDocument document) {
@@ -815,10 +827,7 @@ public class RosettaFormatter extends AbstractRosettaFormatter2 {
 						.feature(RosettaPackage.Literals.ROSETTA_EXTERNAL_ENUM_VALUE__OPERATOR),
 				IHiddenRegionFormatter::oneSpace);
 		formattingUtil.indentInner(externalEnumValue, document);
-		externalEnumValue.getExternalEnumSynonyms().forEach(syn -> {
-			document.prepend(syn, IHiddenRegionFormatter::newLine);
-			document.format(syn);
-		});
+		formatAnnotations(externalEnumValue, document);
 	}
 
 	private void indentedBraces(EObject eObject, IFormattableDocument document) {


### PR DESCRIPTION
Backport of #1381 to `9.x.x`.

Annotations on an attribute were formatted by listing the features that hold them, so the ones added later — labels, rule references and transform annotations — were left untouched. Annotation formatting is now driven off the actual contents of an element, so every annotation is formatted and a new kind of annotation needs no change there.

Separately, an annotation qualifier such as `[metadata address "pointsTo"=Bar->baz]` was not formatted at all; it now is.

`[ruleReference empty]` has only keyword assignments, so Xtext's region access gave it no region and the formatter threw a `NullPointerException` on it. The grammar rule gets an explicit action so the object always has a region.

`[ingest ...]` and an annotation reference now accept a fully qualified name, e.g. `[ingest my.model.MySchema]` and `[my.annotations.myAnnotation]`; scoping already resolved those, only the parser rule was limited to simple names. Syntax highlighting matches qualified names in transform, custom, rule reference and doc reference annotations.

## Backport adaptation

`9.x.x` still has synonyms, which `10.x` does not, so the port needed three decisions in `RosettaFormatter`:

- Synonyms are annotations too, so `isAnnotation` gains a `RosettaSynonymBase` and a `RosettaExternalSynonym` clause, and the hand-rolled synonym loops are dropped in favour of `formatAnnotations`. Every other call site is then identical to `main`.
- That also formats two things `9.x.x` never formatted: an external attribute's rule references (the upstream `testRuleReferenceInRuleSource` covers this) and a `choice`'s synonyms.
- `9.x.x` already had a `formatSingleLineAnnotation` with the same body as the one the port introduces, so the port's copy is dropped and its javadoc moved onto the existing method.

One test is added, `formatSynonymOnChoiceAndOnExternalEnumValue`, covering the two branch-specific paths that had none: a synonym on a `choice`, and an external enum value's synonym in a `synonym source`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M45ugrJEvsE5997CtsRVbT
