### PR TITLE
Warn instead of silently allowing duplicate condition names

### DIFF
--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/ConditionValidatorTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/ConditionValidatorTest.java
@@ -46,4 +46,45 @@ public class ConditionValidatorTest extends AbstractValidatorTest {
 						x exists
 				""");
 	}
+
+	@Test
+	void shouldGenerateDuplicateConditionNameWarningForType() {
+		assertIssues("""
+				type Foo:
+					x string (0..1)
+					y string (0..1)
+
+					condition Bar:
+						x exists
+
+					condition Bar:
+						y exists
+				""", """
+				WARNING (RosettaIssueCodes.duplicateConditionName) 'Duplicate condition 'Bar' in type 'Foo'' at 8:12, length 3, on Condition
+				WARNING (RosettaIssueCodes.duplicateConditionName) 'Duplicate condition 'Bar' in type 'Foo'' at 11:12, length 3, on Condition
+				""");
+	}
+
+	@Test
+	void shouldGenerateDuplicateConditionNameWarningForFunction() {
+		assertIssues("""
+				func Foo:
+					inputs:
+						x string (0..1)
+					output:
+						result string (0..1)
+
+					condition Bar:
+						x exists
+
+					condition Bar:
+						x exists
+
+					set result:
+						x
+				""", """
+				WARNING (RosettaIssueCodes.duplicateConditionName) 'Duplicate condition 'Bar' in Function 'Foo'' at 10:12, length 3, on Condition
+				WARNING (RosettaIssueCodes.duplicateConditionName) 'Duplicate condition 'Bar' in Function 'Foo'' at 13:12, length 3, on Condition
+				""");
+	}
 }

--- a/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/ConditionValidatorTest.java
+++ b/rune-integration-tests/src/test/java/com/regnosys/rosetta/validation/ConditionValidatorTest.java
@@ -87,4 +87,60 @@ public class ConditionValidatorTest extends AbstractValidatorTest {
 				WARNING (RosettaIssueCodes.duplicateConditionName) 'Duplicate condition 'Bar' in Function 'Foo'' at 13:12, length 3, on Condition
 				""");
 	}
+
+	@Test
+	void shouldGenerateDuplicateConditionNameWarningWhenShadowingInheritedCondition() {
+		assertIssues("""
+				type Foo:
+					x string (0..1)
+
+					condition Bar:
+						x exists
+
+				type Sub extends Foo:
+					y string (0..1)
+
+					condition Bar:
+						y exists
+				""", """
+				WARNING (RosettaIssueCodes.duplicateConditionName) 'Duplicate condition 'Bar' in type 'Sub'' at 13:12, length 3, on Condition
+				""");
+	}
+
+	@Test
+	void shouldNotGenerateDuplicateConditionNameWarningForConstraintConditions() {
+		// The name of a `one-of`/`choice` constraint is conventional boilerplate, not an identifier.
+		assertNoIssues("""
+				type Foo:
+					x string (0..1)
+					y string (0..1)
+
+					condition Choice:
+						optional choice x, y
+
+				type Sub extends Foo:
+					z string (0..1)
+					w string (0..1)
+
+					condition Choice:
+						optional choice z, w
+				""");
+	}
+
+	@Test
+	void shouldNotGenerateDuplicateConditionNameWarningForUnrelatedTypes() {
+		assertNoIssues("""
+				type Foo:
+					x string (0..1)
+
+					condition Bar:
+						x exists
+
+				type Other:
+					y string (0..1)
+
+					condition Bar:
+						y exists
+				""");
+	}
 }

--- a/rune-lang/src/main/java/com/regnosys/rosetta/validation/RosettaIssueCodes.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/validation/RosettaIssueCodes.java
@@ -38,6 +38,7 @@ public interface RosettaIssueCodes {
 	static final String INVALID_ELEMENT_NAME=PREFIX +"invalidElementName";
 	static final String UNUSED_IMPORT = PREFIX + "unusedImport";
 	static final String DUPLICATE_IMPORT = PREFIX + "duplicateImport";
+	static final String DUPLICATE_CONDITION_NAME = PREFIX + "duplicateConditionName";
 
 	static final String MANDATORY_SQUARE_BRACKETS = PREFIX + "mandatorySquareBrackets";
 	static final String REDUNDANT_SQUARE_BRACKETS = PREFIX + "redundantSquareBrackets";

--- a/rune-lang/src/main/java/com/regnosys/rosetta/validation/names/DuplicationCluster.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/validation/names/DuplicationCluster.java
@@ -2,5 +2,8 @@ package com.regnosys.rosetta.validation.names;
 
 import org.eclipse.emf.ecore.EClass;
 
-public record DuplicationCluster(EClass clusterType, ClusterScope clusterScope, boolean caseSensitive) {
+public record DuplicationCluster(EClass clusterType, ClusterScope clusterScope, boolean caseSensitive, Severity severity, String issueCode) {
+    public enum Severity {
+        ERROR, WARNING
+    }
 }

--- a/rune-lang/src/main/java/com/regnosys/rosetta/validation/names/RosettaNamesAreUniqueValidationHelper.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/validation/names/RosettaNamesAreUniqueValidationHelper.java
@@ -9,6 +9,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.resource.ISelectable;
 import org.eclipse.xtext.validation.NamesAreUniqueValidationHelper;
@@ -49,6 +50,7 @@ public class RosettaNamesAreUniqueValidationHelper extends NamesAreUniqueValidat
             .put(RosettaPackage.eINSTANCE.getRosettaScope(), "scope")
             .put(RosettaPackage.eINSTANCE.getSchema(), "schema")
             .put(SimplePackage.eINSTANCE.getAttribute(), "attribute")
+            .put(SimplePackage.eINSTANCE.getCondition(), "condition")
             .build();
     
     private final RosettaUniqueNamesConfig config;
@@ -145,6 +147,20 @@ public class RosettaNamesAreUniqueValidationHelper extends NamesAreUniqueValidat
     
     private boolean isInOverriddenNamespace(IEObjectDescription description) {
         return "true".equals(description.getUserData(IN_OVERRIDDEN_NAMESPACE));
+    }
+
+    @Override
+    protected void createDuplicateNameError(IEObjectDescription description, EClass clusterType,
+                                             ValidationMessageAcceptor acceptor) {
+        DuplicationCluster cluster = config.getDuplicationCluster(clusterType);
+        if (cluster != null && cluster.severity() == DuplicationCluster.Severity.WARNING) {
+            EObject object = description.getEObjectOrProxy();
+            EStructuralFeature feature = getNameFeature(object);
+            acceptor.acceptWarning(getDuplicateNameErrorMessage(description, clusterType, feature), object, feature,
+                    ValidationMessageAcceptor.INSIGNIFICANT_INDEX, cluster.issueCode());
+            return;
+        }
+        super.createDuplicateNameError(description, clusterType, acceptor);
     }
 
     @Override

--- a/rune-lang/src/main/java/com/regnosys/rosetta/validation/names/RosettaUniqueNamesConfig.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/validation/names/RosettaUniqueNamesConfig.java
@@ -1,5 +1,6 @@
 package com.regnosys.rosetta.validation.names;
 
+import com.regnosys.rosetta.RosettaEcoreUtil;
 import com.regnosys.rosetta.rosetta.RosettaNamed;
 import com.regnosys.rosetta.rosetta.RosettaPackage;
 import com.regnosys.rosetta.rosetta.RosettaSymbol;
@@ -12,9 +13,12 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.EcoreUtil2;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Configure which unique name checks to run.
@@ -22,11 +26,13 @@ import java.util.Map;
 @Singleton
 public class RosettaUniqueNamesConfig {
     private final ClusterScopes scopes;
+    private final RosettaEcoreUtil rosettaEcoreUtil;
     private final Map<EClass, DuplicationCluster> duplicationClusters = new HashMap<>();
-    
+
     @Inject
-    public RosettaUniqueNamesConfig(ClusterScopes scopes) {
+    public RosettaUniqueNamesConfig(ClusterScopes scopes, RosettaEcoreUtil rosettaEcoreUtil) {
         this.scopes = scopes;
+        this.rosettaEcoreUtil = rosettaEcoreUtil;
         initialize();
     }
     
@@ -68,8 +74,12 @@ public class RosettaUniqueNamesConfig {
         // Check function symbols have a unique name
         addLocalCheck(RosettaPackage.eINSTANCE.getRosettaSymbol(), RosettaSymbol.class, this::getFunctionContainer, this::getFunctionSymbols, true);
 
-        // Check conditions in a type or function have a unique name. This is a warning rather than an error,
-        // because some existing production models already have duplicate condition names.
+        // Check conditions in a type or function have a unique name. Conditions are inherited: the
+        // validation of a type runs the conditions of its super types as well, and a condition in a
+        // sub type does not override an equally named one in a super type - both are evaluated. So
+        // just like attributes, a condition name must also be unique across the type hierarchy.
+        // This is a warning rather than an error, because some existing production models already
+        // have duplicate condition names.
         addLocalCheck(SimplePackage.eINSTANCE.getCondition(), Condition.class, this::getConditionContainer, this::getConditionSiblings, true,
                 DuplicationCluster.Severity.WARNING, RosettaIssueCodes.DUPLICATE_CONDITION_NAME);
     }
@@ -86,6 +96,11 @@ public class RosettaUniqueNamesConfig {
     }
 
     private Object getConditionContainer(Condition condition) {
+        if (rosettaEcoreUtil.isConstraintCondition(condition)) {
+            // The name of a `one-of`/`choice` constraint is conventional boilerplate (it is even
+            // optional), not an identifier, so such conditions are excluded from this check.
+            return null;
+        }
         EObject container = condition.eContainer();
         if (container instanceof Function function) {
             return new ConditionListKey(function, condition.isPostCondition());
@@ -94,12 +109,32 @@ public class RosettaUniqueNamesConfig {
     }
     private Iterable<Condition> getConditionSiblings(Object container) {
         if (container instanceof ConditionListKey key) {
-            return key.postCondition() ? key.function().getPostConditions() : key.function().getConditions();
+            List<Condition> conditions = new ArrayList<>();
+            addCheckedConditions(conditions, key.postCondition() ? key.function().getPostConditions() : key.function().getConditions());
+            return conditions;
+        }
+        if (container instanceof Data data) {
+            // Include the conditions of all super types, so a condition cannot shadow an inherited one.
+            List<Condition> conditions = new ArrayList<>();
+            Set<Data> visited = new HashSet<>();
+            for (Data current = data; current != null && visited.add(current); current = current.getSuperType()) {
+                addCheckedConditions(conditions, current.getConditions());
+            }
+            return conditions;
         }
         if (container instanceof RosettaTypeWithConditions typeWithConditions) {
-            return typeWithConditions.getConditions();
+            List<Condition> conditions = new ArrayList<>();
+            addCheckedConditions(conditions, typeWithConditions.getConditions());
+            return conditions;
         }
         return List.of();
+    }
+    private void addCheckedConditions(List<Condition> result, List<Condition> candidates) {
+        for (Condition condition : candidates) {
+            if (!rosettaEcoreUtil.isConstraintCondition(condition)) {
+                result.add(condition);
+            }
+        }
     }
     private record ConditionListKey(Function function, boolean postCondition) {}
 

--- a/rune-lang/src/main/java/com/regnosys/rosetta/validation/names/RosettaUniqueNamesConfig.java
+++ b/rune-lang/src/main/java/com/regnosys/rosetta/validation/names/RosettaUniqueNamesConfig.java
@@ -3,7 +3,9 @@ package com.regnosys.rosetta.validation.names;
 import com.regnosys.rosetta.rosetta.RosettaNamed;
 import com.regnosys.rosetta.rosetta.RosettaPackage;
 import com.regnosys.rosetta.rosetta.RosettaSymbol;
+import com.regnosys.rosetta.rosetta.RosettaTypeWithConditions;
 import com.regnosys.rosetta.rosetta.simple.*;
+import com.regnosys.rosetta.validation.RosettaIssueCodes;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.eclipse.emf.ecore.EClass;
@@ -11,6 +13,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.EcoreUtil2;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -64,19 +67,42 @@ public class RosettaUniqueNamesConfig {
         
         // Check function symbols have a unique name
         addLocalCheck(RosettaPackage.eINSTANCE.getRosettaSymbol(), RosettaSymbol.class, this::getFunctionContainer, this::getFunctionSymbols, true);
+
+        // Check conditions in a type or function have a unique name. This is a warning rather than an error,
+        // because some existing production models already have duplicate condition names.
+        addLocalCheck(SimplePackage.eINSTANCE.getCondition(), Condition.class, this::getConditionContainer, this::getConditionSiblings, true,
+                DuplicationCluster.Severity.WARNING, RosettaIssueCodes.DUPLICATE_CONDITION_NAME);
     }
-    
+
     private Data getDirectDataContainer(Attribute attr) {
         return containerOfType(attr, Data.class);
     }
-    
+
     private Function getFunctionContainer(RosettaSymbol symbol) {
         return EcoreUtil2.getContainerOfType(symbol, Function.class);
     }
     private Iterable<RosettaSymbol> getFunctionSymbols(Function function) {
         return EcoreUtil2.getAllContentsOfType(function, RosettaSymbol.class);
     }
-    
+
+    private Object getConditionContainer(Condition condition) {
+        EObject container = condition.eContainer();
+        if (container instanceof Function function) {
+            return new ConditionListKey(function, condition.isPostCondition());
+        }
+        return container;
+    }
+    private Iterable<Condition> getConditionSiblings(Object container) {
+        if (container instanceof ConditionListKey key) {
+            return key.postCondition() ? key.function().getPostConditions() : key.function().getConditions();
+        }
+        if (container instanceof RosettaTypeWithConditions typeWithConditions) {
+            return typeWithConditions.getConditions();
+        }
+        return List.of();
+    }
+    private record ConditionListKey(Function function, boolean postCondition) {}
+
     private <T> T containerOfType(EObject eObject, Class<T> clazz) {
         EObject parent = eObject.eContainer();
         if (clazz.isInstance(parent)) {
@@ -93,9 +119,15 @@ public class RosettaUniqueNamesConfig {
     }
     
     protected void addGlobalCheck(EClass clusterType, boolean caseSensitive) {
-        duplicationClusters.put(clusterType, new DuplicationCluster(clusterType, scopes.global(), caseSensitive));
+        addGlobalCheck(clusterType, caseSensitive, DuplicationCluster.Severity.ERROR, null);
+    }
+    protected void addGlobalCheck(EClass clusterType, boolean caseSensitive, DuplicationCluster.Severity severity, String issueCode) {
+        duplicationClusters.put(clusterType, new DuplicationCluster(clusterType, scopes.global(), caseSensitive, severity, issueCode));
     }
     protected <Parent, Child extends RosettaNamed> void addLocalCheck(EClass clusterType, Class<Child> childClass, java.util.function.Function<Child, Parent> getParent, java.util.function.Function<Parent, Iterable<Child>> getChildren, boolean caseSensitive) {
-        duplicationClusters.put(clusterType, new DuplicationCluster(clusterType, scopes.local(childClass, getParent, getChildren), caseSensitive));
+        addLocalCheck(clusterType, childClass, getParent, getChildren, caseSensitive, DuplicationCluster.Severity.ERROR, null);
+    }
+    protected <Parent, Child extends RosettaNamed> void addLocalCheck(EClass clusterType, Class<Child> childClass, java.util.function.Function<Child, Parent> getParent, java.util.function.Function<Parent, Iterable<Child>> getChildren, boolean caseSensitive, DuplicationCluster.Severity severity, String issueCode) {
+        duplicationClusters.put(clusterType, new DuplicationCluster(clusterType, scopes.local(childClass, getParent, getChildren), caseSensitive, severity, issueCode));
     }
 }


### PR DESCRIPTION
## Summary
- Two `condition` blocks in the same type or function could share the same name with no diagnostic at all — noticed while investigating naming behaviour that used to be restricted.
- Conditions are also **inherited**: a type's validation runs its super types' conditions too (`ModelMetaGenerator` collects `allSuperTypes.flatMap[conditions]`), and a same-named condition in a sub type does **not** override the inherited one — the generated class name is derived from the enclosing type, so both classes exist and **both are evaluated**. That silent shadowing had no diagnostic either.
- So, just like attributes, a condition name must now be unique both among siblings and across the type hierarchy.
- Rather than a bespoke check, this plugs `Condition` into the existing duplicate-name checking mechanism (`RosettaUniqueNamesConfig` / `RosettaNamesAreUniqueValidationHelper`, the same infrastructure used for duplicate attributes and function symbols), with a local cluster scope that walks `superType` for types, and treats a function's `conditions`/`postConditions` as separate scopes.
- That mechanism always reported a hard `ERROR`. It's now extended with a per-cluster `Severity` (`DuplicationCluster`), so the condition-name check specifically reports a `WARNING` (`RosettaIssueCodes.duplicateConditionName`) — several production models already have duplicate and shadowed condition names, so a hard error would be a breaking change. All other duplicate-name checks (types, attributes, function symbols, …) keep their original `ERROR` severity.
- Constraint conditions (`one-of` / `choice`) are excluded: their name is conventional boilerplate rather than an identifier, and it is optional — `condition Choice:` is reused freely across type hierarchies in existing models.

## Test plan
- [x] `ConditionValidatorTest`: duplicates within a type, within a function, shadowing an inherited condition, unrelated types (no warning), constraint conditions (no warning)
- [x] `mvnd -pl rune-integration-tests -am test` (full module test suite)
- [x] Full `mvnd install`

Prepared by SimonAgent (whale). Slack thread: https://simonagent.slack.com (see #pull-requests announcement)